### PR TITLE
Cannot redeclare function

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.install
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.install
@@ -22,7 +22,7 @@ function mailchimp_ecommerce_commerce_update_7001() {
 /**
  * Delete unused default currency variable.
  */
-function mailchimp_ecommerce_update_7002() {
+function mailchimp_ecommerce_commerce_update_7002() {
   variable_del('mailchimp_ecommere_commerce_default_currency');
 }
 


### PR DESCRIPTION
The function mailchimp_ecommerce_update_7002() exists in mailchimp_ecommerce, and so an error is thrown upon enabling of mailchimp_ecommerce_commerce.module. Easy solution is to correct the redeclared function name.