### PR TITLE
Queue API option for MailChimp API calls

### DIFF
--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -84,13 +84,6 @@ function mailchimp_ecommerce_admin_settings() {
     '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
   ];
 
-  // Identify the eCommerce platform to MailChimp. This value is set in this
-  // module's submodules for both Drupal Commerce and Ubercart.
-  $form['platform'] = [
-    '#type' => 'hidden',
-    '#default_value' => '',
-  ];
-
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -56,6 +56,12 @@ function mailchimp_ecommerce_admin_settings() {
     '#description' => t('This is overridden if you have selected to use the default currency from Commerce.'),
   ];
 
+  $list_options = [
+    '' => '-- Select --',
+    1 => 'Normal Subscriber',
+    0 => 'Transactional Subscriber',
+  ];
+
   if (!empty(variable_get('mailchimp_ecommerce_list_id', ''))) {
     $form['sync'] = [
       '#type' => 'fieldset',

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -80,15 +80,6 @@ function mailchimp_ecommerce_admin_settings() {
     '#default_value' => '',
   ];
 
-  $form['mailchimp_ecommerce_use_queue'] = [
-    '#type' => 'radios',
-    '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],
-    '#title' => t('Use Queue'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('mailchimp_ecommerce_use_queue', 0),
-    '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
-  ];
-
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -73,6 +73,13 @@ function mailchimp_ecommerce_admin_settings() {
     ];
   }
 
+  // Identify the eCommerce platform to MailChimp. This value is set in this
+  // module's submodules for both Drupal Commerce and Ubercart.
+  $form['platform'] = [
+    '#type' => 'hidden',
+    '#default_value' => '',
+  ];
+
   $form['mailchimp_ecommerce_use_queue'] = [
     '#type' => 'radios',
     '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -67,7 +67,6 @@ function mailchimp_ecommerce_admin_settings() {
       '#type' => 'fieldset',
       '#title' => t('Data sync'),
       '#collapsible' => FALSE,
-      '#weight' => 99,
     ];
     $form['sync']['products'] = [
       '#markup' => l(t('Sync existing Commerce products to MailChimp'), 'admin/config/services/mailchimp/ecommerce/sync'),
@@ -108,8 +107,7 @@ function mailchimp_ecommerce_admin_settings_submit($form, &$form_state) {
     else {
       mailchimp_ecommerce_update_store($store_id,
         $form_state['values']['mailchimp_ecommerce_store_name'],
-        $currency,
-        $platform);
+        $currency);
     }
   }
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -80,6 +80,15 @@ function mailchimp_ecommerce_admin_settings() {
     '#default_value' => '',
   ];
 
+  $form['mailchimp_ecommerce_use_queue'] = [
+    '#type' => 'radios',
+    '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],
+    '#title' => t('Use Queue'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('mailchimp_ecommerce_use_queue', 0),
+    '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
+  ];
+
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -73,6 +73,15 @@ function mailchimp_ecommerce_admin_settings() {
     ];
   }
 
+  $form['mailchimp_ecommerce_use_queue'] = [
+    '#type' => 'radios',
+    '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],
+    '#title' => t('Use Queue'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('mailchimp_ecommerce_use_queue', 0),
+    '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
+  ];
+
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -74,13 +74,6 @@ function mailchimp_ecommerce_admin_settings() {
     ];
   }
 
-  // Identify the eCommerce platform to MailChimp. This value is set in this
-  // module's submodules for both Drupal Commerce and Ubercart.
-  $form['platform'] = [
-    '#type' => 'hidden',
-    '#default_value' => '',
-  ];
-
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 
@@ -103,8 +96,6 @@ function mailchimp_ecommerce_admin_settings_submit($form, &$form_state) {
     // Determine if a store is being created or updated.
     $existing_store = mailchimp_ecommerce_get_store($store_id);
 
-    $platform = !empty($form_state['values']['platform']) ? $form_state['values']['platform'] : '';
-
     if (empty($existing_store)) {
       $store = [
         'list_id' => isset($form_state['values']['mailchimp_ecommerce_list_id']) ? $form_state['values']['mailchimp_ecommerce_list_id'] : variable_get('mailchimp_ecommerce_list_id'),
@@ -112,7 +103,7 @@ function mailchimp_ecommerce_admin_settings_submit($form, &$form_state) {
         'currency_code' => $currency,
       ];
 
-      mailchimp_ecommerce_add_store($store_id, $store, $platform);
+      mailchimp_ecommerce_add_store($store_id, $store);
     }
     else {
       mailchimp_ecommerce_update_store($store_id,

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -56,17 +56,12 @@ function mailchimp_ecommerce_admin_settings() {
     '#description' => t('This is overridden if you have selected to use the default currency from Commerce.'),
   ];
 
-  $list_options = [
-    '' => '-- Select --',
-    1 => 'Normal Subscriber',
-    0 => 'Transactional Subscriber',
-  ];
-
   if (!empty(variable_get('mailchimp_ecommerce_list_id', ''))) {
     $form['sync'] = [
       '#type' => 'fieldset',
       '#title' => t('Data sync'),
       '#collapsible' => FALSE,
+      '#weight' => 99,
     ];
     $form['sync']['products'] = [
       '#markup' => l(t('Sync existing Commerce products to MailChimp'), 'admin/config/services/mailchimp/ecommerce/sync'),
@@ -111,6 +106,8 @@ function mailchimp_ecommerce_admin_settings_submit($form, &$form_state) {
     // Determine if a store is being created or updated.
     $existing_store = mailchimp_ecommerce_get_store($store_id);
 
+    $platform = !empty($form_state['values']['platform']) ? $form_state['values']['platform'] : '';
+
     if (empty($existing_store)) {
       $store = [
         'list_id' => isset($form_state['values']['mailchimp_ecommerce_list_id']) ? $form_state['values']['mailchimp_ecommerce_list_id'] : variable_get('mailchimp_ecommerce_list_id'),
@@ -118,12 +115,13 @@ function mailchimp_ecommerce_admin_settings_submit($form, &$form_state) {
         'currency_code' => $currency,
       ];
 
-      mailchimp_ecommerce_add_store($store_id, $store);
+      mailchimp_ecommerce_add_store($store_id, $store, $platform);
     }
     else {
       mailchimp_ecommerce_update_store($store_id,
         $form_state['values']['mailchimp_ecommerce_store_name'],
-        $currency);
+        $currency,
+        $platform);
     }
   }
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -73,13 +73,11 @@ function mailchimp_ecommerce_admin_settings() {
     ];
   }
 
-  $form['mailchimp_ecommerce_use_queue'] = [
-    '#type' => 'radios',
-    '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],
-    '#title' => t('Use Queue'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('mailchimp_ecommerce_use_queue', 0),
-    '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
+  // Identify the eCommerce platform to MailChimp. This value is set in this
+  // module's submodules for both Drupal Commerce and Ubercart.
+  $form['platform'] = [
+    '#type' => 'hidden',
+    '#default_value' => '',
   ];
 
   $settings_form = system_settings_form($form);

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -75,15 +75,6 @@ function mailchimp_ecommerce_admin_settings() {
     '#default_value' => '',
   ];
 
-  $form['mailchimp_ecommerce_use_queue'] = [
-    '#type' => 'radios',
-    '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],
-    '#title' => t('Use Queue'),
-    '#required' => TRUE,
-    '#default_value' => variable_get('mailchimp_ecommerce_use_queue', 0),
-    '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
-  ];
-
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -84,6 +84,13 @@ function mailchimp_ecommerce_admin_settings() {
     '#description' => t('Enable this to use the Queue API to process requests as background tasks. Requires Cron.'),
   ];
 
+  // Identify the eCommerce platform to MailChimp. This value is set in this
+  // module's submodules for both Drupal Commerce and Ubercart.
+  $form['platform'] = [
+    '#type' => 'hidden',
+    '#default_value' => '',
+  ];
+
   $settings_form = system_settings_form($form);
   $settings_form['#submit'][] = 'mailchimp_ecommerce_admin_settings_submit';
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -57,19 +57,15 @@ function mailchimp_ecommerce_cron_queue_info() {
 /**
  * Callback to create a queue item.
  *
- * @param $item
- *  An a
- * The properties required vary by the op specified:
- * - 'op'
- *   The operation to be performed by the MailChimp API. This maps
- *   to the actual MailChimp API classes.
- *   Potenial values: addOrder, updateCart, addCart, deleteCart
- * - 'cart_id'
- * - 'store_id'
- * - 'customer'
- *  A fully loaded MailChimp $customer object
- *
- * - 'cart'
+ * @param array $item
+ *   Properties to send to the Queue API.
+ *   - 'op' (string) The operation to be performed by the MailChimp API. This maps
+ *     to the actual MailChimp API methods. 
+ *   - 'cart_id' (string) The ID of the current cart.
+ *   - 'store_id' (string) The Store ID.
+ *   - 'customer' (array) A fully loaded MailChimp $customer. 
+ *   - 'cart'  For cart operations, this is the $order from Drupal.
+ *   - 'order' For order operations, this is the $order from Drupal.
  */
 function mailchimp_ecommerce_create_queue_item($item) {
   $queue = DrupalQueue::get('mailchimp_ecommerce_ops');

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -60,10 +60,10 @@ function mailchimp_ecommerce_cron_queue_info() {
  * @param array $item
  *   Properties to send to the Queue API.
  *   - 'op' (string) The operation to be performed by the MailChimp API. This maps
- *     to the actual MailChimp API methods. 
+ *     to the actual MailChimp API methods.
  *   - 'cart_id' (string) The ID of the current cart.
  *   - 'store_id' (string) The Store ID.
- *   - 'customer' (array) A fully loaded MailChimp $customer. 
+ *   - 'customer' (array) A fully loaded MailChimp $customer.
  *   - 'cart'  For cart operations, this is the $order from Drupal.
  *   - 'order' For order operations, this is the $order from Drupal.
  */

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -38,6 +38,110 @@ function mailchimp_ecommerce_menu() {
   return $items;
 }
 
+
+function mailchimp_ecommerce_use_queue() {
+  return variable_get('mailchimp_ecommerce_use_queue', FALSE);
+}
+
+/**
+ * Implements hook_queue_info().
+ */
+function mailchimp_ecommerce_cron_queue_info() {
+  $queues['mailchimp_ecommerce_ops'] = array(
+    'worker callback' => 'mailchimp_ecommerce_queue_process',
+    'time' => 60,
+  );
+  return $queues;
+}
+
+/**
+ * Callback to create a queue item.
+ *
+ * @param $item
+ *  An a
+ * The properties required vary by the op specified:
+ * - 'op'
+ *   The operation to be performed by the MailChimp API. This maps
+ *   to the actual MailChimp API classes.
+ *   Potenial values: addOrder, updateCart, addCart, deleteCart
+ * - 'cart_id'
+ * - 'store_id'
+ * - 'customer'
+ *  A fully loaded MailChimp $customer object
+ *
+ * - 'cart'
+ */
+function mailchimp_ecommerce_create_queue_item($item) {
+  $queue = DrupalQueue::get('mailchimp_ecommerce_ops');
+  $queue->createItem($item);
+}
+
+/**
+ * Worker function to process a MailChimp eCommerce queue item.
+ *
+ * @param DrupalQueueItem $item
+ *  A Drupal Queue object.
+ */
+function mailchimp_ecommerce_queue_process($item) {
+  $list_id = mailchimp_ecommerce_get_list_id();
+
+  /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+  $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+
+  if (isset($item->customer)) {
+    $customer = $item->customer;
+
+    $store_id = mailchimp_ecommerce_get_store_id();
+    if (empty($store_id)) {
+      return;
+    }
+
+    if (!mailchimp_ecommerce_validate_customer($customer) && !$customer['email_address']) {
+      return;
+    }
+
+    // Pull member information to get member status.
+    $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+    $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+  }
+
+  switch ($item->op) {
+    case 'addCart':
+    case 'updateCart':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->cart_id, $customer, $item->cart);
+      break;
+
+    case 'deleteCart':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->cart_id);
+      break;
+
+    case 'addCartLine':
+    case 'updateCartLine':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->cart_id, $item->line_id, $item->product);
+      break;
+
+    case 'deleteCartLine':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->cart_id, $item->line_id);
+      break;
+
+    case 'addOrder':
+      // Pull member information to get member status.
+      $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+      $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+
+      // Increment customer totals
+      $remote_customer = mailchimp_ecommerce_get_customer($customer['id']);
+      $customer['orders_count'] = $remote_customer->orders_count + 1;
+      $customer['total_spent'] = $remote_customer->total_spent + $item->order['order_total'];
+      $mc_ecommerce->{$item->op}($item->store_id, $item->order_id, $customer, $item->order);
+      break;
+
+    case 'updateOrder':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->order_id, $item->order);
+      break;
+  }
+}
+
 /**
  * Implements hook_page_build().
  */
@@ -282,16 +386,27 @@ function mailchimp_ecommerce_add_cart($cart_id, array $customer, array $cart) {
       $cart['campaign_id'] = $campaign_id;
     }
 
-    $list_id = mailchimp_ecommerce_get_list_id();
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'addCart',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+        'customer' => $customer,
+        'cart' => $cart,
+      ]);
+    }
+    else {
+      $list_id = mailchimp_ecommerce_get_list_id();
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
 
-    // Pull member information to get member status.
-    $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
-    $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+      // Pull member information to get member status.
+      $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+      $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
 
-    $mc_ecommerce->addCart($store_id, $cart_id, $customer, $cart);
+      $mc_ecommerce->addCart($store_id, $cart_id, $customer, $cart);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart: ' . $e->getMessage());
@@ -326,16 +441,27 @@ function mailchimp_ecommerce_update_cart($cart_id, array $customer, array $cart)
       return;
     }
 
-    $list_id = mailchimp_ecommerce_get_list_id();
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'updateCart',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+        'customer' => $customer,
+        'cart' => $cart,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $list_id = mailchimp_ecommerce_get_list_id();
 
-    // Pull member information to get member status.
-    $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
-    $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+      // Pull member information to get member status.
+      $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+      $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
 
-    $mc_ecommerce->updateCart($store_id, $cart_id, $customer, $cart);
+      $mc_ecommerce->updateCart($store_id, $cart_id, $customer, $cart);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart: ' . $e->getMessage());
@@ -356,9 +482,18 @@ function mailchimp_ecommerce_delete_cart($cart_id) {
       throw new Exception('Cannot delete a cart without a store ID.');
     }
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
-    $mc_ecommerce->deleteCart($store_id, $cart_id);
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'deleteCart',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->deleteCart($store_id, $cart_id);
+    }
   }
   catch (Exception $e) {
     if ($e->getCode() == 404) {
@@ -392,9 +527,20 @@ function mailchimp_ecommerce_add_cart_line($cart_id, $line_id, $product) {
       throw new Exception('Cannot add a cart line without a store ID.');
     }
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
-    $mc_ecommerce->addCartLine($store_id, $cart_id, $line_id, $product);
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'addCartLine',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+        'line_id' => $line_id,
+        'product' => $product,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->addCartLine($store_id, $cart_id, $line_id, $product);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart line: ' . $e->getMessage());
@@ -423,9 +569,20 @@ function mailchimp_ecommerce_update_cart_line($cart_id, $line_id, $product) {
       throw new Exception('Cannot update a cart line without a store ID.');
     }
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
-    $mc_ecommerce->updateCartLine($store_id, $cart_id, $line_id, $product);
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'updateCartLine',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+        'line_id' => $line_id,
+        'product' => $product,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->updateCartLine($store_id, $cart_id, $line_id, $product);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart line: ' . $e->getMessage());
@@ -448,9 +605,19 @@ function mailchimp_ecommerce_delete_cart_line($cart_id, $line_id) {
       throw new Exception('Cannot delete a cart line without a store ID.');
     }
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
-    $mc_ecommerce->deleteCartLine($store_id, $cart_id, $line_id);
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'deleteCartLine',
+        'cart_id' => $cart_id,
+        'store_id' => $store_id,
+        'line_id' => $line_id,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->deleteCartLine($store_id, $cart_id, $line_id);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete a cart line: ' . $e->getMessage());
@@ -519,22 +686,32 @@ function mailchimp_ecommerce_add_order($order_id, array $customer, array $order)
       $order['campaign_id'] = $campaign_id;
     }
 
-    $list_id = mailchimp_ecommerce_get_list_id();
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'addOrder',
+        'store_id' => $store_id,
+        'order_id' => $order_id,
+        'customer' => $customer, 
+        'order' => $order,
+      ]);
+    }
+    else {
+      $list_id = mailchimp_ecommerce_get_list_id();
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
 
-    // Pull member information to get member status.
-    $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
-    $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+      // Pull member information to get member status.
+      $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+      $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
 
-    // Increment customer totals
+      // Increment customer totals
+      $remote_customer = mailchimp_ecommerce_get_customer($customer['id']);
+      $customer['orders_count'] = $remote_customer->orders_count + 1;
+      $customer['total_spent'] = $remote_customer->total_spent + $order['order_total'];
 
-    $remote_customer = mailchimp_ecommerce_get_customer($customer['id']);
-    $customer['orders_count'] = $remote_customer->orders_count + 1;
-    $customer['total_spent'] = $remote_customer->total_spent + $order['order_total'];
-
-    $mc_ecommerce->addOrder($store_id, $order_id, $customer, $order);
+      $mc_ecommerce->addOrder($store_id, $order_id, $customer, $order);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add an order: ' . $e->getMessage());
@@ -562,9 +739,19 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
       throw new Exception('Cannot update an order without a store ID.');
     }
 
-    /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
-    $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
-    $mc_ecommerce->updateOrder($store_id, $order_id, $order);
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'updateOrder',
+        'order_id' => $order_id,
+        'store_id' => $store_id,
+        'order' => $order,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->updateOrder($store_id, $order_id, $order);
+    }
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update an order: ' . $e->getMessage());


### PR DESCRIPTION
Work to implement the Queue API for performance.

This branch adds a new option to Queue requests (or not), and when selected, instead of calling the MailChimp API every time something is added/removed to a cart (for example), the request is queued. For performance reasons, this is ideal, because the MailChimp API is quite slow, and without this patch it's possible to have very long delays between clicking "Add to cart" and seeing a response.