### PR TITLE
Only show error messages to admin users

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -1020,9 +1020,7 @@ function mailchimp_ecommerce_get_campaign_id() {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to get campaign: ' . $e->getMessage());
-      if (user_access('administer mailchimp')) {
-        drupal_set_message($e->getMessage(), 'error');
-      }
+      mailchimp_ecommerce_show_error($e->getMessage());
     }
   }
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -209,9 +209,7 @@ function mailchimp_ecommerce_add_store($store_id, $store, $platform) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a new store: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -241,9 +239,7 @@ function mailchimp_ecommerce_update_store($store_id, $name, $currency_code, $pla
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a store: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -276,9 +272,7 @@ function mailchimp_ecommerce_add_customer($customer) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a customer: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -344,9 +338,7 @@ function mailchimp_ecommerce_update_customer($customer) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a customer: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -369,9 +361,7 @@ function mailchimp_ecommerce_delete_customer($customer_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete a customer: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -436,9 +426,7 @@ function mailchimp_ecommerce_add_cart($cart_id, array $customer, array $cart) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -498,9 +486,7 @@ function mailchimp_ecommerce_update_cart($cart_id, array $customer, array $cart)
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -581,9 +567,7 @@ function mailchimp_ecommerce_add_cart_line($cart_id, $line_id, $product) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart line: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -625,9 +609,7 @@ function mailchimp_ecommerce_update_cart_line($cart_id, $line_id, $product) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart line: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -662,9 +644,7 @@ function mailchimp_ecommerce_delete_cart_line($cart_id, $line_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete a cart line: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -691,9 +671,7 @@ function mailchimp_ecommerce_get_order($order_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to get order: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 
   return NULL;
@@ -760,9 +738,7 @@ function mailchimp_ecommerce_add_order($order_id, array $customer, array $order)
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add an order: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -802,9 +778,7 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update an order: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -888,9 +862,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a product: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -954,9 +926,7 @@ function mailchimp_ecommerce_delete_product($product_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete product: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -1006,9 +976,7 @@ function mailchimp_ecommerce_delete_product_variant($product_id, $product_varian
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete product variant: ' . $e->getMessage());
-    if (user_access('administer mailchimp')) {
-      drupal_set_message($e->getMessage(), 'error');
-    }
+    mailchimp_ecommerce_show_error($e->getMessage());
   }
 }
 
@@ -1181,4 +1149,10 @@ function _mailchimp_ecommerce_increment_order_total($email_address, $total_spent
   }
 
   return FALSE;
+}
+
+function mailchimp_ecommerce_show_error($message) {
+  if (user_access('administer mailchimp')) {
+    drupal_set_message($message, 'error');
+  }
 }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -1151,6 +1151,9 @@ function _mailchimp_ecommerce_increment_order_total($email_address, $total_spent
   return FALSE;
 }
 
+/**
+ * Helper function to show an error message for admin users.
+ */
 function mailchimp_ecommerce_show_error($message) {
   if (user_access('administer mailchimp')) {
     drupal_set_message($message, 'error');

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -170,7 +170,7 @@ function mailchimp_ecommerce_get_store($store_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to get store: ' . $e->getMessage());
-      mailchimp_ecommerce_show_error($e->getMessage())
+      mailchimp_ecommerce_show_error($e->getMessage());
     }
   }
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -170,7 +170,9 @@ function mailchimp_ecommerce_get_store($store_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to get store: ' . $e->getMessage());
-      drupal_set_message($e->getMessage(), 'error');
+      if (user_access('administer mailchimp')) {
+        drupal_set_message($e->getMessage(), 'error');
+      }
     }
   }
 
@@ -207,7 +209,9 @@ function mailchimp_ecommerce_add_store($store_id, $store, $platform) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a new store: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -237,7 +241,9 @@ function mailchimp_ecommerce_update_store($store_id, $name, $currency_code, $pla
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a store: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -270,7 +276,9 @@ function mailchimp_ecommerce_add_customer($customer) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a customer: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -301,7 +309,9 @@ function mailchimp_ecommerce_get_customer($customer_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to delete a customer: ' . $e->getMessage());
-      drupal_set_message($e->getMessage(), 'error');
+      if (user_access('administer mailchimp')) {
+        drupal_set_message($e->getMessage(), 'error');
+      }
     }
   }
 
@@ -334,7 +344,9 @@ function mailchimp_ecommerce_update_customer($customer) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a customer: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -357,7 +369,9 @@ function mailchimp_ecommerce_delete_customer($customer_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete a customer: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -422,7 +436,9 @@ function mailchimp_ecommerce_add_cart($cart_id, array $customer, array $cart) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -482,7 +498,9 @@ function mailchimp_ecommerce_update_cart($cart_id, array $customer, array $cart)
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -518,7 +536,9 @@ function mailchimp_ecommerce_delete_cart($cart_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to delete a cart: ' . $e->getMessage());
-      drupal_set_message($e->getMessage(), 'error');
+      if (user_access('administer mailchimp')) {
+        drupal_set_message($e->getMessage(), 'error');
+      }
     }
   }
 }
@@ -561,7 +581,9 @@ function mailchimp_ecommerce_add_cart_line($cart_id, $line_id, $product) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a cart line: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -603,7 +625,9 @@ function mailchimp_ecommerce_update_cart_line($cart_id, $line_id, $product) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update a cart line: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -638,7 +662,9 @@ function mailchimp_ecommerce_delete_cart_line($cart_id, $line_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete a cart line: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -665,7 +691,9 @@ function mailchimp_ecommerce_get_order($order_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to get order: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 
   return NULL;
@@ -732,7 +760,9 @@ function mailchimp_ecommerce_add_order($order_id, array $customer, array $order)
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add an order: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -772,7 +802,9 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update an order: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -856,7 +888,9 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to add a product: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -920,7 +954,9 @@ function mailchimp_ecommerce_delete_product($product_id) {
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete product: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -970,7 +1006,9 @@ function mailchimp_ecommerce_delete_product_variant($product_id, $product_varian
   }
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to delete product variant: ' . $e->getMessage());
-    drupal_set_message($e->getMessage(), 'error');
+    if (user_access('administer mailchimp')) {
+      drupal_set_message($e->getMessage(), 'error');
+    }
   }
 }
 
@@ -1020,7 +1058,9 @@ function mailchimp_ecommerce_get_campaign_id() {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to get campaign: ' . $e->getMessage());
-      drupal_set_message($e->getMessage(), 'error');
+      if (user_access('administer mailchimp')) {
+        drupal_set_message($e->getMessage(), 'error');
+      }
     }
   }
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -170,9 +170,7 @@ function mailchimp_ecommerce_get_store($store_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to get store: ' . $e->getMessage());
-      if (user_access('administer mailchimp')) {
-        drupal_set_message($e->getMessage(), 'error');
-      }
+      mailchimp_ecommerce_show_error($e->getMessage())
     }
   }
 
@@ -303,9 +301,7 @@ function mailchimp_ecommerce_get_customer($customer_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to delete a customer: ' . $e->getMessage());
-      if (user_access('administer mailchimp')) {
-        drupal_set_message($e->getMessage(), 'error');
-      }
+      mailchimp_ecommerce_show_error($e->getMessage());
     }
   }
 
@@ -522,9 +518,7 @@ function mailchimp_ecommerce_delete_cart($cart_id) {
     }
     else {
       mailchimp_ecommerce_log_error_message('Unable to delete a cart: ' . $e->getMessage());
-      if (user_access('administer mailchimp')) {
-        drupal_set_message($e->getMessage(), 'error');
-      }
+      mailchimp_ecommerce_show_error($e->getMessage());
     }
   }
 }


### PR DESCRIPTION
In our experience, customers sometimes will see an error message (after such actions as adding a product to their new cart session) but the error message itself is not something that is really public-facing. The result is that the user sees errors relating to internal API operations such as `addCart` or `updateOrder` when they probably don't need to; seeing the error in bright red might scare away customers, and so we should probably just not show them.

To fix this, I've wrapped calls to `drupal_set_message()` within MC API calls to only show for users who have the `administer mailchimp` permission. This way, we're not scaring away customers, but administrators can have a visual indication that something is wrong.