### PR TITLE
Wrong key for reference field in Commerce admin UI

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -54,7 +54,7 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     if (!empty($field_info)) {
       foreach ($field_info as $field_name => $properties) {
         // Only list product reference fields.
-        if (isset($properties['settings']['referenceable_types'][$product_node_type])) {
+        if (isset($properties['settings']['referenceable_types']])) {
           $node_field_options[$field_name] = $properties['label'];
         }
       }


### PR DESCRIPTION
The foreach() loop that searches node types for reference fields currently looks for the following:

`if (isset($properties['settings']['referenceable_types'][$product_node_type])) { `

However the keys in `$properties['settings']['referenceable_types']` are that of product types, not node types. The result is that this array never returns any field values, because display node types do not exist in this array. Simply looking for the `referenceable_types` array should suffice here, as that indicates the field is an entityreference field.