### PR TITLE
Commerce D7 image urls

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -803,7 +803,7 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
  * @param float $price
  *   The product price.
  */
-function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price) {
+function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '') {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -829,6 +829,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
           'sku' => $sku,
           'url' => $url,
           'price' => $price,
+          'image_url' => $image_url,
         ];
 
         $mc_ecommerce->addProduct($store_id, $product_id, $title, [$variant], [
@@ -879,7 +880,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
  * @param float $price
  *   The product price.
  */
-function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price) {
+function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '') {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -893,6 +894,7 @@ function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $t
       'sku' => $sku,
       'url' => $url,
       'price' => $price,
+      'image_url' => $image_url,
     ]);
   }
   catch (Exception $e) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -23,6 +23,10 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '' => '-- Select --',
   ];
 
+  $image_field_options = $image_styles = [
+    '' => '-- Select --',
+  ];
+
   $node_types = node_type_get_names();
 
   foreach ($node_types as $node_type => $node_name) {
@@ -60,7 +64,7 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
 
         // Image fields
         if (isset($properties['settings']['default_image'])) {
-          $image_fields[$field_name] = $properties['label'];
+          $image_field_options[$field_name] = $properties['label'];
         }
       }
     }
@@ -78,7 +82,7 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
 
   $form['product']['mailchimp_ecommerce_commerce_image_field'] = [
     '#type' => 'select',
-    '#options' => $image_fields,
+    '#options' => $image_field_options,
     '#title' => t('Product image field'),
     '#description' => t('Select the image field used on the above content type.'),
     '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_field', ''),

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -98,7 +98,6 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '#options' => $image_styles,
     '#title' => t('Image style'),
     '#description' => t('The image style to use when sending product images to MailChimp.'),
-    '#required' => TRUE,
     '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_style', ''),
   ];
 

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -53,9 +53,14 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
 
     if (!empty($field_info)) {
       foreach ($field_info as $field_name => $properties) {
-        // Only list product reference fields.
+        // Product reference fields.
         if (isset($properties['settings']['referenceable_types'][$product_node_type])) {
           $node_field_options[$field_name] = $properties['label'];
+        }
+
+        // Image fields
+        if (isset($properties['settings']['default_image'])) {
+          $image_fields[$field_name] = $properties['label'];
         }
       }
     }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -71,6 +71,28 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '#suffix' => '</div>',
   ];
 
+  $form['product']['mailchimp_ecommerce_commerce_image_field'] = [
+    '#type' => 'select',
+    '#options' => $image_fields,
+    '#title' => t('Product image field'),
+    '#description' => t('Select the image field used on the above content type.'),
+    '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_field', ''),
+    '#prefix' => '<div id="node-field-wrapper">',
+    '#suffix' => '</div>',
+  ];
+
+  $image_styles = image_style_options(FALSE);
+  $form['product']['mailchimp_ecommerce_commerce_image_style'] = [
+    '#type' => 'select',
+    '#empty_option' => t('None (original image)'),
+    '#multiple' => FALSE,
+    '#options' => $image_styles,
+    '#title' => t('Image style'),
+    '#description' => t('The image style to use when sending product images to MailChimp.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_style', ''),
+  ];
+
   // Identify Drupal Commerce to MailChimp.
   $form['platform']['#default_value'] = 'Drupal Commerce';
 }
@@ -283,8 +305,9 @@ function mailchimp_ecommerce_commerce_commerce_product_insert($product) {
   $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
   $price = commerce_currency_amount_to_decimal($product_wrapper->commerce_price->amount->value(), $product_wrapper->commerce_price->currency_code->value());
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
+  $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
   // TODO: Get product description from product display, if available.
-  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, '', $product->type, $product->sku, $url, $price);
+  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, '', $product->type, $product->sku, $url, $price, $image_url);
 }
 
 /**
@@ -294,7 +317,8 @@ function mailchimp_ecommerce_commerce_commerce_product_update($product) {
   $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
   $price = commerce_currency_amount_to_decimal($product_wrapper->commerce_price->amount->value(), $product_wrapper->commerce_price->currency_code->value());
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
-  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $product->sku, $url, $price);
+  $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
+  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $product->sku, $url, $price, $image_url);
 }
 
 /**
@@ -529,4 +553,54 @@ function _mailchimp_ecommerce_commerce_build_product_url($product) {
   }
 
   return $url;
+}
+
+/**
+ * Creates am Image URL for a product, from its display node.
+ *
+ * @param object $product
+ *   The Commerce object.
+ *
+ * @return string
+ *   The URL of the image.
+ */
+function _mailchimp_ecommerce_commerce_build_image_url($product) {
+  // Find the node associated with this product.
+  $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
+  $product_node_field = variable_get('mailchimp_ecommerce_product_node_field', '');
+  $image_field = variable_get('mailchimp_ecommerce_commerce_image_field', '');
+  $image_style = variable_get('mailchimp_ecommerce_commerce_image_style', '');
+  $image_url = '';
+
+  if (!empty($product_node_type) && !empty($product_node_field)) {
+    $query = new EntityFieldQuery();
+
+    $query->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', $product_node_type)
+      ->fieldCondition($product_node_field, 'product_id', $product->product_id)
+      ->propertyCondition('status', NODE_PUBLISHED);
+
+    $result = $query->execute();
+
+    if (!empty($result) && !empty($result['node'])) {
+      $node = reset($result['node']);
+
+      if (!empty($image_field) && !empty($image_style)) {
+        $wrapper = entity_metadata_wrapper('node', node_load($node->nid));
+        $image = $wrapper->{$image_field}->value();
+
+        // @TODO: Check cardinality of image field, and send all available images instead of one.
+        if (is_array($image)) {
+          $image = reset($image);
+        }
+
+        // Construct a public URL for this image and the chosen style.
+        $fid = $image['fid'];
+        $file = file_load($fid);
+        $image_url = image_style_url($image_style, $file->uri);
+      }
+    }
+  }
+
+  return $image_url;
 }


### PR DESCRIPTION
This branch adds the following for Commerce integration:

- An "image field" and "image style" option to the admin UI;
- <code>$image_url</code> is now passed to the product insert/update methods;
-  A new helper function <code>_mailchimp_ecommerce_commerce_build_image_url()</code> which pulls the selected image from the product's display node, and returns a URL to the styled image.
- The resulting image_url is sent to MailChimp API along with other product fields.