### PR TITLE
Pull images from product entity

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -595,18 +595,20 @@ function _mailchimp_ecommerce_commerce_build_image_url($product) {
 
   if (!empty($image_field) && !empty($image_style)) {
     $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
-    $image = $product_wrapper->{$image_field}->value();
+    if ($product_wrapper->__isset($image_field) && $product_wrapper->{$image_field}->value()) {
+      $image = $product_wrapper->{$image_field}->value();
 
-    // @TODO: Check cardinality of image field, and send all available images.
-    if (is_array($image)) {
-      $image = reset($image);
+      // @TODO: Check cardinality of image field, and send all available images.
+      if (is_array($image)) {
+        $image = reset($image);
+      }
+
+      // Construct a public URL for this image.
+      // If the product is being added via a node form, we must load the new file.
+      $fid = $image['fid'];
+      $file = file_load($fid);
+      $image_url = image_style_url($image_style, $file->uri);
     }
-
-    // Construct a public URL for this image.
-    // If the product is being added via a node form, we must load the new file.
-    $fid = $image['fid'];
-    $file = file_load($fid);
-    $image_url = image_style_url($image_style, $file->uri);
   }
 
   return $image_url;

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -51,6 +51,8 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     $product_node_type = !empty($form_state['values']['mailchimp_ecommerce_product_node_type']) ? $form_state['values']['mailchimp_ecommerce_product_node_type'] : NULL;
   }
 
+  $product_image_types = [];
+
   // List product reference fields.
   if (!empty($product_node_type)) {
     $field_info = field_info_instances('node', $product_node_type);
@@ -62,10 +64,8 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
           $node_field_options[$field_name] = $properties['label'];
         }
 
-        // Image fields
-        if (isset($properties['settings']['default_image'])) {
-          $image_field_options[$field_name] = $properties['label'];
-        }
+        // Track referenceable product variation types for this field.
+        $product_image_types += array_filter($properties['settings']['referenceable_types']);
       }
     }
   }
@@ -79,6 +79,17 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '#prefix' => '<div id="node-field-wrapper">',
     '#suffix' => '</div>',
   ];
+
+  // Since each product variant can have its own image, inform MailChimp
+  // about any image fields that exist on our enabled product types.
+  foreach ($product_image_types as $product_image_type) {
+    foreach (field_info_instances('commerce_product', $product_image_type) as $field_name => $properties) {
+      $field = field_info_field($field_name);
+      if ($field['type'] == 'image' || $field['type'] == 'file') {
+        $image_field_options[$field['field_name']] = $properties['label'];
+      }
+    }
+  }
 
   $form['product']['mailchimp_ecommerce_commerce_image_field'] = [
     '#type' => 'select',
@@ -569,7 +580,7 @@ function _mailchimp_ecommerce_commerce_build_product_url($product) {
 }
 
 /**
- * Creates am Image URL for a product variant.
+ * Creates an Image URL for a product variant.
  *
  * @param object $product
  *   The Commerce product entity.

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -569,50 +569,33 @@ function _mailchimp_ecommerce_commerce_build_product_url($product) {
 }
 
 /**
- * Creates am Image URL for a product, from its display node.
+ * Creates am Image URL for a product variant.
  *
  * @param object $product
- *   The Commerce object.
+ *   The Commerce product entity.
  *
  * @return string
- *   The URL of the image.
+ *   The external URL of the stylized image.
  */
 function _mailchimp_ecommerce_commerce_build_image_url($product) {
-  // Find the node associated with this product.
-  $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
-  $product_node_field = variable_get('mailchimp_ecommerce_product_node_field', '');
   $image_field = variable_get('mailchimp_ecommerce_commerce_image_field', '');
   $image_style = variable_get('mailchimp_ecommerce_commerce_image_style', '');
   $image_url = '';
 
-  if (!empty($product_node_type) && !empty($product_node_field)) {
-    $query = new EntityFieldQuery();
+  if (!empty($image_field) && !empty($image_style)) {
+    $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+    $image = $product_wrapper->{$image_field}->value();
 
-    $query->entityCondition('entity_type', 'node')
-      ->entityCondition('bundle', $product_node_type)
-      ->fieldCondition($product_node_field, 'product_id', $product->product_id)
-      ->propertyCondition('status', NODE_PUBLISHED);
-
-    $result = $query->execute();
-
-    if (!empty($result) && !empty($result['node'])) {
-      $node = reset($result['node']);
-
-      if (!empty($image_field) && !empty($image_style)) {
-        $wrapper = entity_metadata_wrapper('node', node_load($node->nid));
-        $image = $wrapper->{$image_field}->value();
-
-        // @TODO: Check cardinality of image field, and send all available images instead of one.
-        if (is_array($image)) {
-          $image = reset($image);
-        }
-
-        // Construct a public URL for this image and the chosen style.
-        $fid = $image['fid'];
-        $file = file_load($fid);
-        $image_url = image_style_url($image_style, $file->uri);
-      }
+    // @TODO: Check cardinality of image field, and send all available images.
+    if (is_array($image)) {
+      $image = reset($image);
     }
+
+    // Construct a public URL for this image.
+    // If the product is being added via a node form, we must load the new file.
+    $fid = $image['fid'];
+    $file = file_load($fid);
+    $image_url = image_style_url($image_style, $file->uri);
   }
 
   return $image_url;


### PR DESCRIPTION
This is a follow up to #103.

Code has been refactored so that:
- <code>_mailchimp_ecommerce_commerce_build_image_url()</code> pulls from the product entity, not the display
- The available image field options are collected from the product variation types that were enabled for each reference field.
