### PR TITLE
Stock support for Commerce recommendations

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -807,7 +807,7 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
  * @param int $stock
  *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '', $stock) {
+function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '', $stock = 1) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -891,7 +891,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
  * @param int $stock
  *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '', $stock) {
+function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '', $stock = 1) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -802,8 +802,12 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
  *   The product SKU.
  * @param float $price
  *   The product price.
+ * @param string $image_url
+ *   A URL to a representative product Image.
+ * @param int $stock
+ *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '') {
+function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '', $stock) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -830,6 +834,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
           'url' => $url,
           'price' => $price,
           'image_url' => $image_url,
+          'inventory_quantity' => (int) $stock,
         ];
 
         $mc_ecommerce->addProduct($store_id, $product_id, $title, [$variant], [
@@ -852,6 +857,8 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
         'title' => $title,
         'sku' => $sku,
         'price' => $price,
+        'image_url' => $image_url,
+        'inventory_quantity' => (int) $stock,
       ]);
     }
   }
@@ -879,8 +886,12 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
  *   The product SKU.
  * @param float $price
  *   The product price.
+ * @param string $image_url
+ *   A URL to a representative product Image.
+ * @param int $stock
+ *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '') {
+function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '', $stock) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -895,6 +906,7 @@ function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $t
       'url' => $url,
       'price' => $price,
       'image_url' => $image_url,
+      'inventory_quantity' => (int) $stock,
     ]);
   }
   catch (Exception $e) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -112,8 +112,51 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_style', ''),
   ];
 
+  // If Stock modules are detected, show the admin some options for
+  // handling inventory quantities.
+  // @todo: Allow for any other known Stock modules.
+  if (module_exists('commerce_stock')) {
+    $form['stock'] = [
+      '#type' => 'fieldset',
+      '#title' => t('Inventory'),
+      '#description' => t("Stock module detected. The Fixed Inventory Amount will be used for any products that do not have stock fields configured."),
+      '#collapsible' => FALSE,
+    ];
+    $form['stock']['mailchimp_ecommerce_use_fixed_inventory'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Use fixed inventory'),
+      '#description' => t('Enable to set the Fixed Inventory Amount for all products regardless of stock availability.'),
+      '#default_value' => variable_get('mailchimp_ecommerce_use_fixed_inventory', FALSE),
+    ];
+    $form['stock']['mailchimp_ecommerce_fixed_inventory_amount'] = [
+      '#type' => 'textfield',
+      '#title' => t('Fixed inventory amount'),
+      '#default_value' => variable_get('mailchimp_ecommerce_fixed_inventory_amount', 1),
+    ];
+  }
+
   // Identify Drupal Commerce to MailChimp.
   $form['platform']['#default_value'] = 'Drupal Commerce';
+
+  // Validate our settings.
+  $form['#validate'][] = 'mailchimp_ecommerce_commerce_admin_validate';
+}
+
+/**
+ * Validation handler for our admin settings form.
+ */
+function mailchimp_ecommerce_commerce_admin_validate(&$form, &$form_state) {
+  // Make sure the inventory amount is an integer.
+  $amount = $form_state['values']['mailchimp_ecommerce_fixed_inventory_amount'];
+  if (!empty($amount) && !is_numeric($amount) && !is_int($amount)) {
+    form_set_error('mailchimp_ecommerce_fixed_inventory_amount', 'Inventory amount must be an integer.');
+    return FALSE;
+  }
+
+  // If a blank string was passed in, reset the variable to our default.
+  if ($amount == '') {
+    $form_state['values']['mailchimp_ecommerce_fixed_inventory_amount'] = 1;
+  }
 }
 
 /**
@@ -330,8 +373,9 @@ function mailchimp_ecommerce_commerce_commerce_product_insert($product) {
   $price = commerce_currency_amount_to_decimal($product_wrapper->commerce_price->amount->value(), $product_wrapper->commerce_price->currency_code->value());
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
   $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
+  $stock = _mailchimp_ecommerce_commerce_get_inventory($product);
   // TODO: Get product description from product display, if available.
-  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, '', $product->type, $product->sku, $url, $price, $image_url);
+  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, '', $product->type, $product->sku, $url, $price, $image_url, $stock);
 }
 
 /**
@@ -342,7 +386,8 @@ function mailchimp_ecommerce_commerce_commerce_product_update($product) {
   $price = commerce_currency_amount_to_decimal($product_wrapper->commerce_price->amount->value(), $product_wrapper->commerce_price->currency_code->value());
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
   $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
-  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $product->sku, $url, $price, $image_url);
+  $stock = _mailchimp_ecommerce_commerce_get_inventory($product);
+  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $product->sku, $url, $price, $image_url, $stock);
 }
 
 /**
@@ -612,4 +657,35 @@ function _mailchimp_ecommerce_commerce_build_image_url($product) {
   }
 
   return $image_url;
+}
+
+/**
+ * Find the inventory of a given product.
+ *
+ * @param object $product
+ *   The Commerce product.
+ *
+ * @return int
+ *   The stock amount, or 1 if no options are configured.
+ */
+function _mailchimp_ecommerce_commerce_get_inventory($product) {
+  // A default inventory amount is required for product recommendations.
+  // Setting to 1 is a safe fallback in case no stock modules are enabled.
+  $inventory_amount = variable_get('mailchimp_ecommerce_fixed_inventory_amount', 1);
+
+  // If fixed_inventory is enabled, default to the configured value.
+  if (variable_get('mailchimp_ecommerce_use_fixed_inventory', FALSE) === TRUE) {
+    return $inventory_amount;
+  }
+  // Otherwise, check for the Stock module and use its inventory
+  // if the product has stock enabled.
+  elseif (module_exists('commerce_stock')) {
+    $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
+    if ($product_wrapper->__isset('commerce_stock') && $product_wrapper->commerce_stock->value()) {
+      $inventory_amount = (int) $product_wrapper->commerce_stock->value();
+    }
+  }
+
+  // Fallback to our fixed inventory amount.
+  return $inventory_amount;
 }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -673,19 +673,12 @@ function _mailchimp_ecommerce_commerce_get_inventory($product) {
   // Setting to 1 is a safe fallback in case no stock modules are enabled.
   $inventory_amount = variable_get('mailchimp_ecommerce_fixed_inventory_amount', 1);
 
-  // If fixed_inventory is enabled, default to the configured value.
-  if (variable_get('mailchimp_ecommerce_use_fixed_inventory', FALSE) === TRUE) {
-    return $inventory_amount;
-  }
-  // Otherwise, check for the Stock module and use its inventory
-  // if the product has stock enabled.
-  elseif (module_exists('commerce_stock')) {
+  if (variable_get('mailchimp_ecommerce_use_fixed_inventory', FALSE) == FALSE) {
     $product_wrapper = entity_metadata_wrapper('commerce_product', $product);
     if ($product_wrapper->__isset('commerce_stock') && $product_wrapper->commerce_stock->value()) {
       $inventory_amount = (int) $product_wrapper->commerce_stock->value();
     }
   }
 
-  // Fallback to our fixed inventory amount.
   return $inventory_amount;
 }


### PR DESCRIPTION
This PR does the following:
- Adds options for `use_fixed_inventory` and `fixed_inventory_amount`
- Validates the amount with a new form validation callback
- Creates a helper function for retrieving a product's inventory qty;
- Passes the retrieved stock amount to product `add` and `update` methods
- Fixes a a missing `image_url` property in the addProduct() callback