### PR TITLE
Ubercart product syncing, variants, and coupons

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -800,6 +800,8 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
  *   The product type.
  * @param string $sku
  *   The product SKU.
+ * @param string $url
+ *   The product URL.
  * @param float $price
  *   The product price.
  */

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -1156,3 +1156,23 @@ function mailchimp_ecommerce_show_error($message) {
     drupal_set_message($message, 'error');
   }
 }
+
+/**
+ * Get the human readable name of a node type by the slug.
+ *
+ * @param $type_slug
+ *  slug of a node type
+ *
+ * @return string|false
+ *  String for the name of the type if it exists, otherwise FALSE
+ */
+function mailchimp_ecommerce_get_node_type_name($type_slug) {
+	$all_types = node_type_get_names();
+	$type_name = false;
+
+	if (isset($all_types[$type_slug])) {
+		$type_name = $all_types[$type_slug];
+	}
+
+	return $type_name;
+}

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -824,8 +824,9 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
     }
     catch (Exception $e) {
       if ($e->getCode() == 404) {
+      	// TODO check if product has adjustments with additional SKUs defined. Add these as variants instead of default
         // No existing product; create new product with default variant.
-        $variant = (object) [
+        $variant = [
           'id' => $product_variant_id,
           'title' => $title,
           'sku' => $sku,
@@ -834,7 +835,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
           'image_url' => $image_url,
         ];
 
-        $mc_ecommerce->addProduct($store_id, $product_id, $title, $url, $variant, [
+        $mc_ecommerce->addProduct($store_id, $product_id, $title, $url, [$variant], [
           'description' => $description,
           'type' => $type,
         ]);

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -834,7 +834,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
           'image_url' => $image_url,
         ];
 
-        $mc_ecommerce->addProduct($store_id, $product_id, $title, [$variant], [
+        $mc_ecommerce->addProduct($store_id, $product_id, $title, $url, $variant, [
           'description' => $description,
           'type' => $type,
         ]);

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -278,8 +278,6 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
  * Implements hook_uc_order().
  */
 function mailchimp_ecommerce_ubercart_uc_order($op, $order) {
-	/*debug*/ mq_dd($op);
-
   if ($op == 'new') {
     $mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -203,6 +203,7 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
  * Implements hook_uc_order().
  */
 function mailchimp_ecommerce_ubercart_uc_order($op, $order) {
+	// TODO: cannot properly sync cart line items until MailChimp has info on all product variants since variant ID = SKU
   if ($op == 'new') {
     $mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -127,8 +127,6 @@ function mailchimp_ecommerce_ubercart_admin_sync_submit($form, &$form_state) {
 			->execute()
 			->fetchCol();
 
-		//*debug*/ dd($result, __FUNCTION__.'() $result');
-
 		if (count($result)) {
 			$product_ids = array_unique($result);
 			$batch['operations'][] = [

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -71,7 +71,7 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
 		    $variant['title'],
 		    $product['description'],
 		    $product['type'],
-		    $product['sku'],
+		    $variant['sku'],
 		    $product['url'],
 		    $variant['price']);
     }

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -83,7 +83,7 @@ function mailchimp_ecommerce_ubercart_mailchimp_ecommerce_add_store($store) {
 	$query = db_select('node', 'n')
 		->fields('n', ['nid']);
 	$query->join('node_type', 'nt', 'n.type = nt.type');
-	$nids = $query->condition('nt.base', 'uc_product')
+	$nids = $query->condition('nt.base', ['uc_product', 'uc_product_kit'], 'IN')
 		->execute()
 		->fetchCol();
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -168,25 +168,6 @@ function mailchimp_ecommerce_ubercart_batch_add_products($product_ids, &$context
 }
 
 /**
- * Batch callback used to add a product to MailChimp.
- */
-function mailchimp_ecommerce_ubercart_batch_add_product($product_id, &$context) {
-  $node = node_load($product_id);
-
-  $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
-
-  mailchimp_ecommerce_add_product(
-    $product['id'],
-    $product['variant_id'],
-    $product['title'],
-    $product['description'],
-    $product['type'],
-    $product['sku'],
-    $product['url'],
-    $product['price']);
-}
-
-/**
  * Gets MailChimp product values from an Ubercart product node.
  *
  * @param object $node

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -20,6 +20,7 @@ function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_settings_al
  * Implements hook_node_insert().
  */
 function mailchimp_ecommerce_ubercart_node_insert($node) {
+	// @TODO: implement better check for products (can be of any type defined in node_types w/ base = uc_product
   if ($node->type == 'product') {
     // Create a corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
@@ -76,6 +77,8 @@ function mailchimp_ecommerce_ubercart_mailchimp_ecommerce_add_store($store) {
     'operations' => [],
   ];
 
+
+  // @todo update to use EntityFieldQuery, types should come from node_type table where base = uc_product
   $products = node_load_multiple([], [
     'type' => 'product',
   ]);
@@ -94,6 +97,72 @@ function mailchimp_ecommerce_ubercart_mailchimp_ecommerce_add_store($store) {
   }
 
   batch_set($batch);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_sync_alter(&$form, &$form_state) {
+	$form['#submit'][] = 'mailchimp_ecommerce_ubercart_admin_sync_submit';
+}
+
+/**
+ * Submit handler for the MailChimp eCommerce sync form.
+ */
+function mailchimp_ecommerce_ubercart_admin_sync_submit($form, &$form_state) {
+	if (!empty($form_state['values']['sync_products'])) {
+		$batch = [
+			'title' => t('Adding products to MailChimp'),
+			'operations' => [],
+		];
+
+		$result = db_select('uc_products', 'ucp')
+			->fields('ucp', ['nid'])
+			->execute()
+			->fetchCol();
+
+		//*debug*/ dd($result, __FUNCTION__.'() $result');
+
+		if (count($result)) {
+			$product_ids = array_unique($result);
+			$batch['operations'][] = [
+				'mailchimp_ecommerce_ubercart_batch_add_products',
+				[$product_ids],
+			];
+		}
+
+		batch_set($batch);
+	}
+}
+
+/**
+ * Batch callback used to add products to MailChimp.
+ */
+function mailchimp_ecommerce_ubercart_batch_add_products($product_ids, &$context) {
+	if (!isset($context['sandbox']['progress'])) {
+		$context['sandbox']['progress'] = 0;
+		$context['sandbox']['total'] = count($product_ids);
+		$context['results']['product_ids'] = $product_ids;
+	}
+
+	$batch_limit = variable_get('mailchimp_batch_limit', 100);
+
+	$batch = array_slice($context['results']['product_ids'], $context['sandbox']['progress'], $batch_limit);
+
+	foreach ($batch as $product_id) {
+		$node = node_load($product_id);
+
+		mailchimp_ecommerce_ubercart_node_insert($node);
+
+		$context['sandbox']['progress']++;
+
+		$context['message'] = t('Sent @count of @total products to MailChimp', [
+			'@count' => $context['sandbox']['progress'],
+			'@total' => $context['sandbox']['total'],
+		]);
+
+		$context['finished'] = ($context['sandbox']['progress'] / $context['sandbox']['total']);
+	}
 }
 
 /**

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -183,7 +183,7 @@ function mailchimp_ecommerce_ubercart_batch_add_products($product_ids, &$context
 function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
   $node_wrapper = entity_metadata_wrapper('node', $node);
 
-  // TODO: consider product adjustments that define additional variatns and skus per product - uc_product_adjustments
+  // TODO: consider product adjustments that define additional variations and skus per product - uc_product_adjustments
   $product = array(
     'id' => $node_wrapper->nid->value(),
     'variant_id' => $node_wrapper->model->value(),
@@ -193,8 +193,7 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
   'description' => (isset($node_wrapper->body->value()['value'])) ? $node_wrapper->body->value()['value'] : '',
     'price' => $node_wrapper->sell_price->value(),
     'url' => _mailchimp_ecommerce_ubercart_build_product_url($node_wrapper->nid->value()),
-    // TODO: Ubercart product types.
-    'type' => '',
+    'type' => mailchimp_ecommerce_get_node_type_name($node_wrapper->getPropertyInfo()['type']),
   );
 
   return $product;

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -278,7 +278,8 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
  * Implements hook_uc_order().
  */
 function mailchimp_ecommerce_ubercart_uc_order($op, $order) {
-	// TODO: cannot properly sync cart line items until MailChimp has info on all product variants since variant ID = SKU
+	/*debug*/ mq_dd($op);
+
   if ($op == 'new') {
     $mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 
@@ -343,6 +344,7 @@ function mailchimp_ecommerce_ubercart_uc_order($op, $order) {
 function mailchimp_ecommerce_ubercart_build_order($order) {
   $currency_code = $order->currency;
   $order_total = '';
+  $discount_total = 0;
   $lines = [];
 
   $billing_address = mailchimp_ecommerce_ubercart_parse_billing_address($order);
@@ -355,15 +357,20 @@ function mailchimp_ecommerce_ubercart_build_order($order) {
   $products = uc_cart_get_contents();
   if (!empty($products)) {
     foreach ($products as $product) {
-      $line = [
-        'id' => $product->cart_item_id,
-        'product_id' => $product->nid,
-        'product_variant_id' => $product->model,
-        'quantity' => (int) $product->qty,
-        'price' => $product->price,
-      ];
+      if ($product->module === "uc_coupon") {
+      	// calculate discount_total for order
+	    $discount_total += $product->price;
+      } else {
+	      $line = [
+		      'id'                 => $product->cart_item_id,
+		      'product_id'         => $product->nid,
+		      'product_variant_id' => $product->model,
+		      'quantity'           => (int) $product->qty,
+		      'price'              => $product->price,
+	      ];
 
-      $lines[] = $line;
+	      $lines[] = $line;
+      }
     }
   }
 
@@ -380,6 +387,7 @@ function mailchimp_ecommerce_ubercart_build_order($order) {
   $order_data = [
     'currency_code' => $currency_code,
     'order_total' => $order_total,
+	'discount_total' => abs($discount_total),
     'billing_address' => $billing_address,
     'processed_at_foreign' => date('c'),
     'lines' => $lines,

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -24,6 +24,18 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
     // Create a corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
+    // get variants
+		$attributes = uc_product_get_attributes($node->nid);
+		$variants = [];
+
+		// Get variant adjusted price, and modified title (from UC option name)
+		$combinations = db_select('uc_product_adjustments', 'pa')
+			$variants[$sku]['variant_id'] = $sku;
+			$variants[$sku]['price'] = $product['price'] + $variant_data->price;
+		}
+	}
+
+	// add base product
     mailchimp_ecommerce_add_product(
       $product['id'],
       $product['variant_id'],
@@ -44,6 +56,8 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
     // Update the corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
+    // TODO refactor to use mailchimp_ecommerce_update_product and handle variants
+
     mailchimp_ecommerce_add_product(
       $product['id'],
       $product['variant_id'],
@@ -53,6 +67,22 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
       $product['sku'],
       $product['url'],
       $product['price']);
+  }
+
+  // add variants
+  if (!empty($variants)) {
+  	foreach ($variants as $variant) {
+  		// mailchimp_ecommerce_add_product() will add variants if product already exists
+	    mailchimp_ecommerce_add_product(
+		    $product['id'],
+		    $variant['variant_id'],
+		    $variant['title'],
+		    $product['description'],
+		    $product['type'],
+		    $product['sku'],
+		    $product['url'],
+		    $variant['price']);
+    }
   }
 }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -25,39 +25,31 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
     // get variants
+	if (module_exists('uc_attribute')) {
 		$attributes = uc_product_get_attributes($node->nid);
 		$variants = [];
 
 		// Get variant adjusted price, and modified title (from UC option name)
 		$combinations = db_select('uc_product_adjustments', 'pa')
+			->fields('pa', ['combination', 'model'])
+			->condition('pa.nid', $node->nid)
+			->execute()
+			->fetchAllKeyed();
+
+		foreach ($combinations as $serialized_combo => $sku) {
+			$combo = unserialize($serialized_combo);
+			$option_id = reset($combo);
+			$attribute_id = key($combo);
+			$variant_data = $attributes[$attribute_id]->options[$option_id];
+
+			// store variant data for adding to MC API
 			$variants[$sku]['variant_id'] = $sku;
+			$variants[$sku]['title'] = $product['title'] . ' (' . $attributes[$attribute_id]->label . ': '. $variant_data->name . ')';
 			$variants[$sku]['price'] = $product['price'] + $variant_data->price;
 		}
 	}
 
 	// add base product
-    mailchimp_ecommerce_add_product(
-      $product['id'],
-      $product['variant_id'],
-      $product['title'],
-      $product['description'],
-      $product['type'],
-      $product['sku'],
-      $product['url'],
-      $product['price']);
-  }
-}
-
-/**
- * Implements hook_node_update().
- */
-function mailchimp_ecommerce_ubercart_node_update($node) {
-  if (uc_product_is_product($node)) {
-    // Update the corresponding MailChimp product.
-    $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
-
-    // TODO refactor to use mailchimp_ecommerce_update_product and handle variants
-
     mailchimp_ecommerce_add_product(
       $product['id'],
       $product['variant_id'],
@@ -83,6 +75,28 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
 		    $product['url'],
 		    $variant['price']);
     }
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function mailchimp_ecommerce_ubercart_node_update($node) {
+  if (uc_product_is_product($node)) {
+    // Update the corresponding MailChimp product.
+    $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
+
+    // TODO refactor to use mailchimp_ecommerce_update_product and handle variants
+
+    mailchimp_ecommerce_add_product(
+      $product['id'],
+      $product['variant_id'],
+      $product['title'],
+      $product['description'],
+      $product['type'],
+      $product['sku'],
+      $product['url'],
+      $product['price']);
   }
 }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -193,7 +193,7 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
   'description' => (isset($node_wrapper->body->value()['value'])) ? $node_wrapper->body->value()['value'] : '',
     'price' => $node_wrapper->sell_price->value(),
     'url' => _mailchimp_ecommerce_ubercart_build_product_url($node_wrapper->nid->value()),
-    'type' => mailchimp_ecommerce_get_node_type_name($node_wrapper->getPropertyInfo()['type']),
+    'type' => mailchimp_ecommerce_get_node_type_name($node_wrapper->getBundle()),
   );
 
   return $product;

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -179,6 +179,7 @@ function mailchimp_ecommerce_ubercart_batch_add_products($product_ids, &$context
 function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
   $node_wrapper = entity_metadata_wrapper('node', $node);
 
+  // TODO: consider product adjustments that define additional variatns and skus per product - uc_product_adjustments
   $product = array(
     'id' => $node_wrapper->nid->value(),
     'variant_id' => $node_wrapper->model->value(),

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -79,10 +79,15 @@ function mailchimp_ecommerce_ubercart_mailchimp_ecommerce_add_store($store) {
   ];
 
 
-  // @todo update to use EntityFieldQuery, types should come from node_type table where base = uc_product
-  $products = node_load_multiple([], [
-    'type' => 'product',
-  ]);
+  // select all nodes that are types of products
+	$query = db_select('node', 'n')
+		->fields('n', ['nid']);
+	$query->join('node_type', 'nt', 'n.type = nt.type');
+	$nids = $query->condition('nt.base', 'uc_product')
+		->execute()
+		->fetchCol();
+
+	$products = node_load_multiple($nids);
 
   if (!empty($products)) {
     $product_ids = array_keys($products);

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -86,6 +86,7 @@ function mailchimp_ecommerce_ubercart_get_product_variant_values($product) {
 
 			// store variant data for adding to MC API
 			$variants[$sku]['variant_id'] = $sku;
+			$variants[$sku]['sku'] = $sku;
 			$variants[$sku]['title'] = $product['title'] . ' (' . $attributes[$attribute_id]->label . ': '. $variant_data->name . ')';
 			$variants[$sku]['price'] = $product['price'] + $variant_data->price;
 		}
@@ -122,7 +123,7 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
 					$product['id'],
 					$variant['variant_id'],
 					$variant['title'],
-					$product['sku'],
+					$variant['sku'],
 					$product['url'],
 					$variant['price']
 				);

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -206,6 +206,7 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
     'url' => $alias = drupal_get_path_alias($node->nid),
   'description' => (isset($node_wrapper->body->value()['value'])) ? $node_wrapper->body->value()['value'] : '',
     'price' => $node_wrapper->sell_price->value(),
+    'url' => _mailchimp_ecommerce_ubercart_build_product_url($node_wrapper->nid->value()),
     // TODO: Ubercart product types.
     'type' => '',
   );
@@ -355,3 +356,21 @@ function mailchimp_ecommerce_ubercart_parse_billing_address($order) {
 // TODO: Implement mailchimp_ecommerce_update_customer()
 // TODO: Implement mailchimp_ecommerce_delete_customer()
 // TODO: Implement mailchimp_ecommerce_get_customer()
+
+
+/**
+ * Creates a URL from a product, as long as the product is referenced by a node.
+ *
+ * @param object $product
+ *   The Commerce object.
+ * @return string
+ *   The URL of the node referencing the product.
+ */
+function _mailchimp_ecommerce_ubercart_build_product_url($nid) {
+	global $base_url;
+
+	$path = drupal_get_path_alias('node/' . $nid);
+	$url = $base_url . '/' . $path;
+
+	return $url;
+}

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -127,8 +127,6 @@ function mailchimp_ecommerce_ubercart_admin_sync_submit($form, &$form_state) {
 			->execute()
 			->fetchCol();
 
-		//*debug*/ dd($result, __FUNCTION__.'() $result');
-
 		if (count($result)) {
 			$product_ids = array_unique($result);
 			$batch['operations'][] = [
@@ -190,7 +188,7 @@ function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
     'sku' => $node_wrapper->model->value(),
     'title' => $node_wrapper->title->value(),
     'url' => $alias = drupal_get_path_alias($node->nid),
-  'description' => (isset($node_wrapper->body->value()['value'])) ? $node_wrapper->body->value()['value'] : '',
+    'description' => (isset($node_wrapper->body->value()['value'])) ? $node_wrapper->body->value()['value'] : '',
     'price' => $node_wrapper->sell_price->value(),
     'url' => _mailchimp_ecommerce_ubercart_build_product_url($node_wrapper->nid->value()),
     'type' => mailchimp_ecommerce_get_node_type_name($node_wrapper->getBundle()),

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -258,7 +258,6 @@ function mailchimp_ecommerce_ubercart_batch_add_products($product_ids, &$context
 function mailchimp_ecommerce_ubercart_get_product_values_from_node($node) {
   $node_wrapper = entity_metadata_wrapper('node', $node);
 
-  // TODO: consider product adjustments that define additional variations and skus per product - uc_product_adjustments
   $product = array(
     'id' => $node_wrapper->nid->value(),
     'variant_id' => $node_wrapper->model->value(),

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -25,29 +25,7 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
     // get variants
-	if (module_exists('uc_attribute')) {
-		$attributes = uc_product_get_attributes($node->nid);
-		$variants = [];
-
-		// Get variant adjusted price, and modified title (from UC option name)
-		$combinations = db_select('uc_product_adjustments', 'pa')
-			->fields('pa', ['combination', 'model'])
-			->condition('pa.nid', $node->nid)
-			->execute()
-			->fetchAllKeyed();
-
-		foreach ($combinations as $serialized_combo => $sku) {
-			$combo = unserialize($serialized_combo);
-			$option_id = reset($combo);
-			$attribute_id = key($combo);
-			$variant_data = $attributes[$attribute_id]->options[$option_id];
-
-			// store variant data for adding to MC API
-			$variants[$sku]['variant_id'] = $sku;
-			$variants[$sku]['title'] = $product['title'] . ' (' . $attributes[$attribute_id]->label . ': '. $variant_data->name . ')';
-			$variants[$sku]['price'] = $product['price'] + $variant_data->price;
-		}
-	}
+	$variants = mailchimp_ecommerce_ubercart_get_product_variant_values($product);
 
 	// add base product
     mailchimp_ecommerce_add_product(
@@ -73,32 +51,87 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
 		    $product['type'],
 		    $variant['sku'],
 		    $product['url'],
-		    $variant['price']);
+		    $variant['price']
+	    );
     }
   }
+}
+
+/**
+ * Returns an array of variant specific data from a product.
+ *
+ * @param $product
+ *  array of product info from mailchimp_ecommerce_ubercart_get_product_values_from_node()
+ *
+ * @return array
+ */
+function mailchimp_ecommerce_ubercart_get_product_variant_values($product) {
+	$variants = [];
+
+	if (module_exists('uc_attribute')) {
+		$attributes = uc_product_get_attributes($product['id']);
+
+		// Get variant adjusted price, and modified title (from UC option name)
+		$combinations = db_select('uc_product_adjustments', 'pa')
+			->fields('pa', ['combination', 'model'])
+			->condition('pa.nid', $product['id'])
+			->execute()
+			->fetchAllKeyed();
+
+		foreach ($combinations as $serialized_combo => $sku) {
+			$combo = unserialize($serialized_combo);
+			$option_id = reset($combo);
+			$attribute_id = key($combo);
+			$variant_data = $attributes[$attribute_id]->options[$option_id];
+
+			// store variant data for adding to MC API
+			$variants[$sku]['variant_id'] = $sku;
+			$variants[$sku]['title'] = $product['title'] . ' (' . $attributes[$attribute_id]->label . ': '. $variant_data->name . ')';
+			$variants[$sku]['price'] = $product['price'] + $variant_data->price;
+		}
+	}
+
+	return $variants;
 }
 
 /**
  * Implements hook_node_update().
  */
 function mailchimp_ecommerce_ubercart_node_update($node) {
-  if (uc_product_is_product($node)) {
-    // Update the corresponding MailChimp product.
-    $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
+	if (uc_product_is_product($node)) {
+		// Update the corresponding MailChimp product.
+		$product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
-    // TODO refactor to use mailchimp_ecommerce_update_product and handle variants
+		// get variants
+		$variants = mailchimp_ecommerce_ubercart_get_product_variant_values($product);
 
-    mailchimp_ecommerce_add_product(
-      $product['id'],
-      $product['variant_id'],
-      $product['title'],
-      $product['description'],
-      $product['type'],
-      $product['sku'],
-      $product['url'],
-      $product['price']);
-  }
+		// update base variant
+		mailchimp_ecommerce_update_product(
+			$product['id'],
+			$product['variant_id'],
+			$product['title'],
+			$product['sku'],
+			$product['url'],
+			$product['price']
+		);
+
+		// add variants
+		if (!empty($variants)) {
+			foreach ($variants as $variant) {
+				mailchimp_ecommerce_update_product(
+					$product['id'],
+					$variant['variant_id'],
+					$variant['title'],
+					$product['sku'],
+					$product['url'],
+					$variant['price']
+				);
+			}
+		}
+	}
 }
+
+// TODO update product when Ubercart Attributes, Options, or Adjustments are saved
 
 /**
  * Implements hook_node_delete().

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -20,8 +20,7 @@ function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_settings_al
  * Implements hook_node_insert().
  */
 function mailchimp_ecommerce_ubercart_node_insert($node) {
-	// @TODO: implement better check for products (can be of any type defined in node_types w/ base = uc_product
-  if ($node->type == 'product') {
+  if (uc_product_is_product($node)) {
     // Create a corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
@@ -41,7 +40,7 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
  * Implements hook_node_update().
  */
 function mailchimp_ecommerce_ubercart_node_update($node) {
-  if ($node->type == 'product') {
+  if (uc_product_is_product($node)) {
     // Update the corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 
@@ -61,7 +60,7 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
  * Implements hook_node_delete().
  */
 function mailchimp_ecommerce_ubercart_node_delete($node) {
-  if ($node->type == 'product') {
+  if (uc_product_is_product($node)) {
     // Delete the corresponding MailChimp product.
     $product = mailchimp_ecommerce_ubercart_get_product_values_from_node($node);
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -32,6 +32,7 @@ function mailchimp_ecommerce_ubercart_node_insert($node) {
       $product['description'],
       $product['type'],
       $product['sku'],
+      $product['url'],
       $product['price']);
   }
 }
@@ -51,6 +52,7 @@ function mailchimp_ecommerce_ubercart_node_update($node) {
       $product['description'],
       $product['type'],
       $product['sku'],
+      $product['url'],
       $product['price']);
   }
 }
@@ -180,6 +182,7 @@ function mailchimp_ecommerce_ubercart_batch_add_product($product_id, &$context) 
     $product['description'],
     $product['type'],
     $product['sku'],
+    $product['url'],
     $product['price']);
 }
 


### PR DESCRIPTION
This PR does the following:

• Fixes MailChimp API schema errors to allow products to sync successfully
* Add support for addition Ubercart product content types
• Add support for product variants defined using `uc_attribute` module Attributes, Options and Adjustments
• Adds support for `uc_coupon` module: correctly handles coupon line items, calculates `discount_total` from coupons
