### PR TITLE
Implement hook_commerce_cart_product_remove

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -187,6 +187,16 @@ function mailchimp_ecommerce_commerce_batch_add_products($product_ids, &$context
 }
 
 /**
+ * Implements hook_commerce_cart_product_remove().
+ *
+ * Removing a product from a shopping cart requires
+ * deleting the cartLine from MailChimp.
+ */
+function mailchimp_ecommerce_commerce_commerce_cart_product_remove($order, $product, $quantity, $line_item) {
+  mailchimp_ecommerce_delete_cart_line($order->order_id, $line_item->line_item_id);
+}
+
+/**
  * Implements hook_commerce_customer_profile_insert().
  */
 function mailchimp_ecommerce_commerce_commerce_customer_profile_insert($customer_profile) {


### PR DESCRIPTION
In my testing, it appears that we can't simply overwrite the `lines` array within a Cart when removing a product the same way we can when adding one. This means implementing cart-specific hooks to ensure the MC cartLine is deleted at the same time.