### PR TITLE
Implement Commerce hooks for MC API integration

### DIFF
--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -87,7 +87,7 @@ function mailchimp_ecommerce_admin_settings() {
     '#options' => [1 => 'Send all active Carts', 0 => 'Send completed orders only'],
     '#title' => t('Send Carts to MailChimp'),
     '#default_value' => variable_get('mailchimp_ecommerce_send_carts', FALSE),
-    '#description' => t('When enabled, Shopping Carts and orders are sent to MailChimp. When disabled, only completed Orders are sent during Checkout completion.'),
+    '#description' => t('When enabled, shopping carts are sent to MailChimp during each step of their lifecycle. When disabled, only completed orders are sent during Checkout completion.'),
   ];
 
   $form['mailchimp_ecommerce_use_queue'] = [

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -86,7 +86,6 @@ function mailchimp_ecommerce_admin_settings() {
     '#type' => 'checkbox',
     '#options' => [1 => 'Send all active Carts', 0 => 'Send completed orders only'],
     '#title' => t('Send Carts to MailChimp'),
-    '#required' => TRUE,
     '#default_value' => variable_get('mailchimp_ecommerce_send_carts', FALSE),
     '#description' => t('When enabled, Shopping Carts and orders are sent to MailChimp. When disabled, only completed Orders are sent during Checkout completion.'),
   ];

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -82,6 +82,15 @@ function mailchimp_ecommerce_admin_settings() {
     '#default_value' => '',
   ];
 
+  $form['mailchimp_ecommerce_send_carts'] = [
+    '#type' => 'checkbox',
+    '#options' => [1 => 'Send all active Carts', 0 => 'Send completed orders only'],
+    '#title' => t('Send Carts to MailChimp'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('mailchimp_ecommerce_send_carts', TRUE),
+    '#description' => t('When enabled, Shopping Carts and orders are sent to MailChimp. When disabled, only completed Orders are sent during Checkout completion.'),
+  ];
+
   $form['mailchimp_ecommerce_use_queue'] = [
     '#type' => 'radios',
     '#options' => [ 1  => 'Queue requests', 0 => 'Do not use queue'],

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -87,7 +87,7 @@ function mailchimp_ecommerce_admin_settings() {
     '#options' => [1 => 'Send all active Carts', 0 => 'Send completed orders only'],
     '#title' => t('Send Carts to MailChimp'),
     '#required' => TRUE,
-    '#default_value' => variable_get('mailchimp_ecommerce_send_carts', TRUE),
+    '#default_value' => variable_get('mailchimp_ecommerce_send_carts', FALSE),
     '#description' => t('When enabled, Shopping Carts and orders are sent to MailChimp. When disabled, only completed Orders are sent during Checkout completion.'),
   ];
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -135,6 +135,15 @@ function mailchimp_ecommerce_queue_process($item) {
     case 'updateOrder':
       $mc_ecommerce->{$item->op}($item->store_id, $item->order_id, $item->order);
       break;
+
+    case 'deleteOrder':
+      $mc_ecommerce->{$item->op}($item->store_id, $item->order_id, $item->order);
+
+      // Decrement customer totals.
+      $remote_customer = mailchimp_ecommerce_get_customer($customer['id']);
+      $customer['orders_count'] = $remote_customer->orders_count - 1;
+      $customer['total_spent'] = $remote_customer->total_spent - $item->order['order_total'];
+      break;
   }
 }
 
@@ -773,6 +782,43 @@ function mailchimp_ecommerce_update_order($order_id, array $order) {
   catch (Exception $e) {
     mailchimp_ecommerce_log_error_message('Unable to update an order: ' . $e->getMessage());
     mailchimp_ecommerce_show_error($e->getMessage());
+  }
+}
+
+/**
+ * Deletes an Order from the current MailChimp store.
+ *
+ * @param string $order_id
+ *   The Order ID.
+ */
+function mailchimp_ecommerce_delete_order($order_id) {
+  try {
+    $store_id = mailchimp_ecommerce_get_store_id();
+    if (empty($store_id)) {
+      throw new Exception('Cannot delete an order without a store ID.');
+    }
+
+    if (mailchimp_ecommerce_use_queue()) {
+      mailchimp_ecommerce_create_queue_item([
+        'op' => 'deleteOrder',
+        'cart_id' => $order_id,
+        'store_id' => $store_id,
+      ]);
+    }
+    else {
+      /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
+      $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
+      $mc_ecommerce->deleteOrder($store_id, $order_id);
+    }
+  }
+  catch (Exception $e) {
+    if ($e->getCode() == 404) {
+      // Cart doesn't exist; no need to log an error.
+    }
+    else {
+      mailchimp_ecommerce_log_error_message('Unable to delete a cart: ' . $e->getMessage());
+      mailchimp_ecommerce_show_error($e->getMessage());
+    }
   }
 }
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -809,6 +809,15 @@ function mailchimp_ecommerce_delete_order($order_id) {
       /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
       $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
       $mc_ecommerce->deleteOrder($store_id, $order_id);
+
+      // Pull member information to get member status.
+      $memberinfo = mailchimp_get_memberinfo($list_id, $customer['email_address'], TRUE);
+      $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
+
+      // Decrement customer totals.
+      $remote_customer = mailchimp_ecommerce_get_customer($customer['id']);
+      $customer['orders_count'] = $remote_customer->orders_count - 1;
+      $customer['total_spent'] = $remote_customer->total_spent - $item->order['order_total'];
     }
   }
   catch (Exception $e) {

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -822,10 +822,10 @@ function mailchimp_ecommerce_delete_order($order_id) {
   }
   catch (Exception $e) {
     if ($e->getCode() == 404) {
-      // Cart doesn't exist; no need to log an error.
+      // Order doesn't exist; no need to log an error.
     }
     else {
-      mailchimp_ecommerce_log_error_message('Unable to delete a cart: ' . $e->getMessage());
+      mailchimp_ecommerce_log_error_message('Unable to delete an order: ' . $e->getMessage());
       mailchimp_ecommerce_show_error($e->getMessage());
     }
   }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -801,7 +801,7 @@ function mailchimp_ecommerce_delete_order($order_id) {
     if (mailchimp_ecommerce_use_queue()) {
       mailchimp_ecommerce_create_queue_item([
         'op' => 'deleteOrder',
-        'cart_id' => $order_id,
+        'order_id' => $order_id,
         'store_id' => $store_id,
       ]);
     }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -190,6 +190,13 @@ function mailchimp_ecommerce_commerce_batch_add_products($product_ids, &$context
  * Implements hook_commerce_cart_product_add().
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product, $quantity, $line_item) {
+  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+
+  // Do not send Carts to MailChimp if we're not configured to.
+  if ($send_carts == FALSE) {
+    return;
+  }
+
   // If this order is new, that means this is the first line item;
   // send the entire cart to MailChimp first.
   if ($order->created == $order->changed) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -208,6 +208,16 @@ function mailchimp_ecommerce_commerce_commerce_order_update($order){
 }
 
 /**
+ * Implements hook_commerce_order_delete().
+ */
+function mailchimp_ecommerce_commerce_commerce_order_delete($order) {
+  $cart_statuses = array_keys(commerce_order_statuses(array('state' => 'cart')));
+  if (in_array($order->status, $cart_statuses)) {
+    mailchimp_ecommerce_delete_cart($order->order_id);
+  }
+}
+
+/**
  * Implements hook_commerce_cart_product_add().
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product, $quantity, $line_item) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -211,8 +211,13 @@ function mailchimp_ecommerce_commerce_commerce_order_update($order){
  * Implements hook_commerce_order_delete().
  */
 function mailchimp_ecommerce_commerce_commerce_order_delete($order) {
-  $cart_statuses = array_keys(commerce_order_statuses(array('state' => 'cart')));
-  if (in_array($order->status, $cart_statuses)) {
+  // If this order was completed, it is an MC Order.
+  $post_checkout = array_keys(commerce_order_statuses(array('state' => 'completed')));
+  if (in_array($order->status, $post_checkout)) {
+    mailchimp_ecommerce_delete_order($order->order_id);
+  }
+  // Otherwise it's a cart.
+  else {
     mailchimp_ecommerce_delete_cart($order->order_id);
   }
 }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -187,6 +187,29 @@ function mailchimp_ecommerce_commerce_batch_add_products($product_ids, &$context
 }
 
 /**
+ * Implements hook_commerce_cart_product_add().
+ */
+function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product, $quantity, $line_item) {
+  // If this order is new, that means this is the first line item;
+  // send the entire cart to MailChimp first.
+  if ($order->created == $order->changed) {
+    _mailchimp_ecommerce_commerce_send_cart($order);
+  }
+  else {
+    $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
+    $cart_product = [
+      'product_id' => $product->product_id,
+      'product_variant_id' => $product->sku,
+      'quantity' => $quantity,
+      'price' => commerce_currency_amount_to_decimal(
+        $line_item_wrapper->commerce_unit_price->amount->value(),
+        $line_item_wrapper->commerce_unit_price->currency_code->value()),
+    ];
+    mailchimp_ecommerce_add_cart_line($order->order_id, $line_item->line_item_id, $cart_product);
+  }
+}
+
+/**
  * Implements hook_commerce_cart_product_remove().
  *
  * Removing a product from a shopping cart requires
@@ -373,7 +396,7 @@ function mailchimp_ecommerce_commerce_default_rules_configuration() {
 
   $rule->label = t('Send cart to MailChimp');
   $rule->tags = ['Commerce Cart'];
-  $rule->active = TRUE;
+  $rule->active = FALSE;
 
   $rule
     ->event('commerce_cart_product_add')

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -436,7 +436,7 @@ function mailchimp_ecommerce_commerce_default_rules_configuration() {
 
   $rule->label = t('Send cart to MailChimp');
   $rule->tags = ['Commerce Cart'];
-  $rule->active = FALSE;
+  $rule->active = TRUE;
 
   $rule
     ->event('commerce_cart_product_add')

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -223,7 +223,40 @@ function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product
  * deleting the cartLine from MailChimp.
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_remove($order, $product, $quantity, $line_item) {
+  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+
+  // Do not send Carts to MailChimp if we're not configured to.
+  if ($send_carts == FALSE) {
+    return;
+  }
+
   mailchimp_ecommerce_delete_cart_line($order->order_id, $line_item->line_item_id);
+}
+
+/**
+ * Implements hook_commerce_line_item_update().
+ */
+function mailchimp_ecommerce_commerce_commerce_line_item_update($line_item) {
+  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+
+  // Do not send Carts to MailChimp if we're not configured to.
+  if ($send_carts == FALSE) {
+    return;
+  }
+
+  $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
+  if (in_array($line_item_wrapper->type->value(), commerce_product_line_item_types())) {
+    $product = $line_item_wrapper->commerce_product->value();
+    $mc_product = [
+      'product_id' => $product->product_id,
+      'product_variant_id' => $product->sku,
+      'quantity' => $line_item->quantity,
+      'price' => commerce_currency_amount_to_decimal(
+        $line_item_wrapper->commerce_unit_price->amount->value(),
+        $line_item_wrapper->commerce_unit_price->currency_code->value()),
+    ];
+    mailchimp_ecommerce_update_cart_line($line_item->order_id, $line_item->line_item_id, $mc_product);
+  }
 }
 
 /**

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -187,6 +187,27 @@ function mailchimp_ecommerce_commerce_batch_add_products($product_ids, &$context
 }
 
 /**
+ * Implements hook_commerce_order_update().
+ *
+ * When an in-progress cart order changes status, notify
+ * MailChimp if we're configured to do so.
+ */
+function mailchimp_ecommerce_commerce_commerce_order_update($order){
+  $send_carts = variable_get('mailchimp_ecommerce_send_carts', FALSE);
+
+  // Only send a cart if we are in cart or checkout status, and the status has changed.
+  if ($send_carts == TRUE && $order->original->status <> $order->status) {
+    $cart_states = array_keys(commerce_order_statuses(array('state' => 'cart')));
+    $checkout_states = array_keys(commerce_order_statuses(array('state' => 'checkout')));
+
+    if (in_array($order->status, $cart_states) || in_array($order->status, $checkout_states)) {
+      // @todo: Handle admin-created orders,
+      _mailchimp_ecommerce_commerce_send_cart($order);
+    }
+  }
+}
+
+/**
  * Implements hook_commerce_cart_product_add().
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product, $quantity, $line_item) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -190,7 +190,7 @@ function mailchimp_ecommerce_commerce_batch_add_products($product_ids, &$context
  * Implements hook_commerce_cart_product_add().
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product, $quantity, $line_item) {
-  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+  $send_carts = variable_get('mailchimp_ecommerce_send_carts', FALSE);
 
   // Do not send Carts to MailChimp if we're not configured to.
   if ($send_carts == FALSE) {
@@ -223,7 +223,7 @@ function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product
  * deleting the cartLine from MailChimp.
  */
 function mailchimp_ecommerce_commerce_commerce_cart_product_remove($order, $product, $quantity, $line_item) {
-  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+  $send_carts = variable_get('mailchimp_ecommerce_send_carts', FALSE);
 
   // Do not send Carts to MailChimp if we're not configured to.
   if ($send_carts == FALSE) {
@@ -237,7 +237,7 @@ function mailchimp_ecommerce_commerce_commerce_cart_product_remove($order, $prod
  * Implements hook_commerce_line_item_update().
  */
 function mailchimp_ecommerce_commerce_commerce_line_item_update($line_item) {
-  $send_carts = variable_get('mailchimp_ecommerce_send_cart', TRUE);
+  $send_carts = variable_get('mailchimp_ecommerce_send_carts', FALSE);
 
   // Do not send Carts to MailChimp if we're not configured to.
   if ($send_carts == FALSE) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -201,7 +201,7 @@ function mailchimp_ecommerce_commerce_commerce_order_update($order){
     $checkout_states = array_keys(commerce_order_statuses(array('state' => 'checkout')));
 
     if (in_array($order->status, $cart_states) || in_array($order->status, $checkout_states)) {
-      // @todo: Handle admin-created orders,
+      // @todo: Handle admin-created orders.
       _mailchimp_ecommerce_commerce_send_cart($order);
     }
   }


### PR DESCRIPTION
In the same vein as #112, for Commerce 1.x's integration, I think we should implement the `commerce_cart_product_add()` hook to react when a product is added to the cart. This way we can send the entire cart for the first product to get added (to make sure MailChimp has the entire order first), and then for subsequent cart product additions, we can send MailChimp just each product that was added.

This PR does this, and sets the default Rules config to be disabled. We may want to actually consider removing it; while Rules integration is nice to have, I think having the Rules Action "Send cart to MailChimp" is plenty. 

The added benefits here are performance, both between the MC API and in Drupal, since we have to do less work for each cart action.

Also, I've come to realize that extra line items such as taxes, discounts, and promos only need to be send with a completed `Order` object, and not with the `Cart` (since those are _prospective_ orders anyway).

This is related to #12, #13, and #14.