### PR TITLE
Sync Ubercart historical orders and customers to MailChimp

### DIFF
--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -70,8 +70,9 @@ function mailchimp_ecommerce_admin_settings() {
       '#collapsible' => FALSE,
       '#weight' => 99,
     ];
+    $platform = module_exists('mailchimp_ecommerce_ubercart') ? 'Ubercart' : 'Commerce';
     $form['sync']['products'] = [
-      '#markup' => l(t('Sync existing Commerce products to MailChimp'), 'admin/config/services/mailchimp/ecommerce/sync'),
+      '#markup' => l(t('Sync existing @platform products to MailChimp', ['@platform'=>$platform]), 'admin/config/services/mailchimp/ecommerce/sync'),
     ];
   }
 

--- a/includes/mailchimp_ecommerce.admin.inc
+++ b/includes/mailchimp_ecommerce.admin.inc
@@ -173,3 +173,35 @@ function mailchimp_ecommerce_admin_sync() {
  */
 function mailchimp_ecommerce_admin_sync_submit($form, &$form_state) {
 }
+
+
+/**
+ * The MailChimp eCommerce historical order data sync form.
+ */
+function mailchimp_ecommerce_admin_sync_orders() {
+	$form['sync_orders'] = [
+		'#type' => 'checkbox',
+		'#title' => t('Sync Orders'),
+		'#description' => t('Sync historical orders to MailChimp.'),
+	];
+
+	$form['timespan'] = [
+		'#type' => 'textfield',
+		'#title' => t('Time span'),
+		'#default_value' => 6,
+		'#field_suffix' => 'months',
+		'#description' => 'MailChimp recommends syncing the past 6 months of order data. Leave blank to sync all orders.',
+		'#size' => 3,
+		'#maxlength' => 3,
+	];
+
+	$form['actions']['submit'] = [
+		'#type' => 'submit',
+		'#value' => t('Sync with MailChimp'),
+	];
+
+	$form['#submit'][] = 'mailchimp_ecommerce_admin_sync_submit';
+
+	return $form;
+}
+

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -672,7 +672,7 @@ function mailchimp_ecommerce_delete_cart_line($cart_id, $line_id) {
  * @return object
  *   The order.
  */
-function mailchimp_ecommerce_get_order($order_id) {
+function mailchimp_ecommerce_get_order($order_id, $log_404 = TRUE) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -685,8 +685,13 @@ function mailchimp_ecommerce_get_order($order_id) {
     return $order;
   }
   catch (Exception $e) {
-    mailchimp_ecommerce_log_error_message('Unable to get order: ' . $e->getMessage());
-    mailchimp_ecommerce_show_error($e->getMessage());
+	  if ($e->getCode() == 404 && !$log_404) {
+		  // Order doesn't exist in the store; no need to log an error.
+	  }
+	  else {
+		  mailchimp_ecommerce_log_error_message('Unable to get order: ' . $e->getMessage());
+		  mailchimp_ecommerce_show_error($e->getMessage());
+	  }
   }
 
   return NULL;

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -321,7 +321,7 @@ function mailchimp_ecommerce_get_customer($customer_id) {
       // Customer doesn't exist in the store; no need to log an error.
     }
     else {
-      mailchimp_ecommerce_log_error_message('Unable to delete a customer: ' . $e->getMessage());
+      mailchimp_ecommerce_log_error_message('Unable to get a customer: ' . $e->getMessage());
       mailchimp_ecommerce_show_error($e->getMessage());
     }
   }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -35,6 +35,18 @@ function mailchimp_ecommerce_menu() {
     'weight' => 21,
   );
 
+	$items['admin/config/services/mailchimp/ecommerce/sync-orders'] = array(
+		'title' => 'eCommerce historical orders sync',
+		'description' => 'Sync past eCommerce order data to MailChimp.',
+		'page callback' => 'drupal_get_form',
+		'page arguments' => array('mailchimp_ecommerce_admin_sync_orders'),
+		'access callback' => 'mailchimp_apikey_ready_access',
+		'access arguments' => array('administer mailchimp'),
+		'file' => 'includes/mailchimp_ecommerce.admin.inc',
+		'type' => MENU_LOCAL_TASK,
+		'weight' => 21,
+	);
+
   return $items;
 }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.api.php
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.api.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the MailChimp eCommerce Ubercart module.
+ */
+
+/**
+ * Allows modules to alter product variant data
+ *
+ * @param array $variants
+ *    Variant specific data from an Ubercart product
+ * @param array $product
+ *    Mailchimp product info. @see mailchimp_ecommerce_ubercart_get_product_values_from_node()
+ */
+function hook_mailchimp_ecommerce_ubercart_product_variant_alter(&$variants, $product) {
+
+}

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -514,13 +514,15 @@ function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
 		$mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 
 		// create customer if they do not already exist
-		if (is_null(mailchimp_ecommerce_get_customer($order->uid))) {
+		$lookup_customer = mailchimp_ecommerce_get_customer($order->uid);
+		if (is_null($lookup_customer)) {
 			// Create new customer in MailChimp.
 			mailchimp_ecommerce_add_customer($mc_order['customer']);
 		}
 
 		// create / update order
-		if (is_null(mailchimp_ecommerce_get_order($order->order_id, FALSE))) {
+		$lookup_order = mailchimp_ecommerce_get_order($order->order_id, FALSE);
+		if (is_null($lookup_order)) {
 			// Create new order in MailChimp.
 			mailchimp_ecommerce_add_order($order->order_id, $mc_order['customer'], $mc_order['order_data']);
 		} else {

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -457,29 +457,82 @@ function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_sync_orders
  * Submit handler for the MailChimp eCommerce sync form.
  */
 function mailchimp_ecommerce_ubercart_admin_sync_orders_submit($form, &$form_state) {
-	/*debug*/ ddl($form_state, __FUNCTION__.'() $form_state');
-
 	if (!empty($form_state['values']['sync_orders'])) {
 		$batch = [
 			'title' => t('Adding orders to MailChimp'),
 			'operations' => [],
 		];
 
-		// @TODO get completed orders within specified time period (months)
+		// get completed orders within specified time period (months)
+		$months = abs(intval($form_state['values']['timespan'])) * -1;
+		$min_timestamp = strtotime($months . ' months');
+		$result = db_select('uc_orders', 'o')
+			->fields('o', ['order_id'])
+			->condition('o.order_status', 'completed')
+			->condition('o.created', $min_timestamp, '>')
+			->execute()
+			->fetchCol();
 
-//		$result = db_select('uc_orders', 'ucp')
-//			->fields('ucp', ['nid'])
-//			->execute()
-//			->fetchCol();
-//
-//		if (count($result)) {
-//			$product_ids = array_unique($result);
-//			$batch['operations'][] = [
-//				'mailchimp_ecommerce_ubercart_batch_add_orders',
-//				[$product_ids],
-//			];
-//		}
+		if (count($result)) {
+			$order_ids = array_unique($result);
+			$batch['operations'][] = [
+				'mailchimp_ecommerce_ubercart_batch_add_orders',
+				[$order_ids],
+			];
+		}
 
 		batch_set($batch);
+	}
+}
+
+/**
+ * Batch callback used to add orders to MailChimp.
+ */
+function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
+	if (!isset($context['sandbox']['progress'])) {
+		$context['sandbox']['progress'] = 0;
+		$context['sandbox']['total'] = count($order_ids);
+		$context['results']['order_ids'] = $order_ids;
+		$context['sandbox']['current_order'] = 0;
+	}
+
+	$batch_limit = variable_get('mailchimp_batch_limit', 100);
+
+	$batch = array_slice($context['results']['order_ids'], $context['sandbox']['progress'], $batch_limit);
+	$orders = uc_order_load_multiple($batch);
+
+	foreach ($orders as $order) {
+		$context['sandbox']['current_order'] = $order->order_id;
+
+		$mc_order = mailchimp_ecommerce_ubercart_build_order($order);
+
+		// create customer if they do not already exist
+		try {
+			mailchimp_ecommerce_get_customer($order->uid);
+		} catch (Exception $e) {
+			// Create new customer in MailChimp.
+			mailchimp_ecommerce_add_customer($mc_order['customer']);
+		}
+
+		// create / update order
+		try {
+			$existing_order = mailchimp_ecommerce_get_order($order->order_id);
+		} catch (Exception $e) {
+			// Create new order in MailChimp.
+			mailchimp_ecommerce_add_order($order->order_id, $mc_order['customer'], $mc_order['order_data']);
+		}
+		if (!empty($existing_order)) {
+			// Update existing order in MailChimp.
+			mailchimp_ecommerce_update_order($order->order_id, $mc_order['order_data']);
+		}
+
+		$context['sandbox']['progress']++;
+
+		$context['message'] = t('Sent @count of @total orders to MailChimp', [
+			'@count' => $context['sandbox']['progress'],
+			'@total' => $context['sandbox']['total'],
+		]);
+
+		$context['finished'] = ($context['sandbox']['progress'] / $context['sandbox']['total']);
 	}
 }

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -507,21 +507,16 @@ function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
 		$mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 
 		// create customer if they do not already exist
-		try {
-			mailchimp_ecommerce_get_customer($order->uid);
-		} catch (Exception $e) {
+		if (is_null(mailchimp_ecommerce_get_customer($order->uid))) {
 			// Create new customer in MailChimp.
 			mailchimp_ecommerce_add_customer($mc_order['customer']);
 		}
 
 		// create / update order
-		try {
-			$existing_order = mailchimp_ecommerce_get_order($order->order_id);
-		} catch (Exception $e) {
+		if (is_null(mailchimp_ecommerce_get_order($order->order_id, FALSE))) {
 			// Create new order in MailChimp.
 			mailchimp_ecommerce_add_order($order->order_id, $mc_order['customer'], $mc_order['order_data']);
-		}
-		if (!empty($existing_order)) {
+		} else {
 			// Update existing order in MailChimp.
 			mailchimp_ecommerce_update_order($order->order_id, $mc_order['order_data']);
 		}

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -356,7 +356,14 @@ function mailchimp_ecommerce_ubercart_build_order($order) {
 
   $order_total = uc_order_get_total($order);
 
-  $products = uc_cart_get_contents();
+  if (empty($order->products)) {
+  	// carts needs separate product lookup
+	  $products = uc_cart_get_contents();
+  } else {
+	  // completed orders are loaded with products
+	  $products = $order->products;
+  }
+
   if (!empty($products)) {
     foreach ($products as $product) {
       if ($product->module === "uc_coupon") {
@@ -364,7 +371,7 @@ function mailchimp_ecommerce_ubercart_build_order($order) {
 	    $discount_total += $product->price;
       } else {
 	      $line = [
-		      'id'                 => $product->cart_item_id,
+		      'id'                 => isset($product->cart_item_id) ? $product->cart_item_id : $product->order_product_id,
 		      'product_id'         => $product->nid,
 		      'product_variant_id' => $product->model,
 		      'quantity'           => (int) $product->qty,

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -369,7 +369,7 @@ function mailchimp_ecommerce_ubercart_build_order($order) {
 
   if (!empty($products)) {
     foreach ($products as $product) {
-      if ($product->module === "uc_coupon") {
+      if (isset($product->module) && $product->module === "uc_coupon") {
       	// calculate discount_total for order
 	    $discount_total += $product->price;
       } else {

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -96,6 +96,9 @@ function mailchimp_ecommerce_ubercart_get_product_variant_values($product) {
 		}
 	}
 
+	// Calling all modules implementing hook_mailchimp_ecommerce_ubercart_product_variant_alter():
+	drupal_alter('mailchimp_ecommerce_ubercart_product_variant', $variants, $product);
+
 	return $variants;
 }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -14,6 +14,10 @@ function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_settings_al
 
   // Identify Ubercart to MailChimp.
   $form['platform']['#default_value'] = 'Drupal Ubercart';
+
+	$form['sync']['orders'] = [
+		'#markup' => '<br>'.l(t('Sync historical orders to MailChimp'), 'admin/config/services/mailchimp/ecommerce/sync-orders'),
+	];
 }
 
 /**

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -517,7 +517,7 @@ function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
 		$mc_order = mailchimp_ecommerce_ubercart_build_order($order);
 
 		// create customer if they do not already exist
-		$lookup_customer = mailchimp_ecommerce_get_customer($order->uid);
+		$lookup_customer = mailchimp_ecommerce_get_customer($mc_order['customer']['id']);
 		if (is_null($lookup_customer)) {
 			// Create new customer in MailChimp.
 			mailchimp_ecommerce_add_customer($mc_order['customer']);

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -445,3 +445,41 @@ function _mailchimp_ecommerce_ubercart_build_product_url($nid) {
 
 	return $url;
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function mailchimp_ecommerce_ubercart_form_mailchimp_ecommerce_admin_sync_orders_alter(&$form, &$form_state) {
+	$form['#submit'][] = 'mailchimp_ecommerce_ubercart_admin_sync_orders_submit';
+}
+
+/**
+ * Submit handler for the MailChimp eCommerce sync form.
+ */
+function mailchimp_ecommerce_ubercart_admin_sync_orders_submit($form, &$form_state) {
+	/*debug*/ ddl($form_state, __FUNCTION__.'() $form_state');
+
+	if (!empty($form_state['values']['sync_orders'])) {
+		$batch = [
+			'title' => t('Adding orders to MailChimp'),
+			'operations' => [],
+		];
+
+		// @TODO get completed orders within specified time period (months)
+
+//		$result = db_select('uc_orders', 'ucp')
+//			->fields('ucp', ['nid'])
+//			->execute()
+//			->fetchCol();
+//
+//		if (count($result)) {
+//			$product_ids = array_unique($result);
+//			$batch['operations'][] = [
+//				'mailchimp_ecommerce_ubercart_batch_add_orders',
+//				[$product_ids],
+//			];
+//		}
+
+		batch_set($batch);
+	}
+}


### PR DESCRIPTION
Provides a UI, similar to syncing products, that allows for past orders and their customers to sync to MailChimp.  The time span for past orders, input as the number of months previous to the current date, can be specified.

This also adds a hook to mailchimp_ecommerce_ubercart_get_product_variant_values() to allow for the product variants array to be altered. My store setup includes other modules that add product variants with different SKUs. Since SKUs are used as variant IDs, all SKUs must be represented in MailChimp in order to send order and cart data. I suspect other sites would also need this functionality.

Additionally, I’ve corrected an error in a the log message text for mailchimp_ecommerce_delete_customer().

I also added an optional parameter to mailchimp_ecommerce_get_order() to avoid logging 404 errors. This allows the function to be used to check if an order already exists in MC. This changes the behavior so it is similar to mailchimp_ecommerce_get_customer().

I’ve tested these new changes with Ubercart on Drupal 7. I’m not sure if any other changes are needed to work with UC on Drupal 8.