### PR TITLE
Update a product variant if it exists when calling addProduct()

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -834,7 +834,8 @@ function mailchimp_ecommerce_delete_order($order_id) {
 /**
  * Adds a product to MailChimp.
  *
- * Adds a product variant if a product with the given ID exists.
+ * Adds a product variant if a product with the given ID exists. Gracefully
+ * handles updating an existing variant.
  *
  * In MailChimp, each product requires at least one product variant. This
  * function will create a single product variant when creating new products.
@@ -910,14 +911,36 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
 
     if (!$new_product) {
       // Add a variant to an existing product.
-      $mc_ecommerce->addProductVariant($store_id, $product_id, [
-        'id' => $product_variant_id,
-        'title' => $title,
-        'sku' => $sku,
-        'price' => $price,
-        'image_url' => $image_url,
-        'inventory_quantity' => (int) $stock,
-      ]);
+      try {
+        $mc_ecommerce->addProductVariant($store_id, $product_id, [
+          'id' => $product_variant_id,
+          'description' => $description,
+          'title' => $title,
+          'sku' => $sku,
+          'price' => $price,
+          'url' => $url,
+          'image_url' => $image_url,
+          'inventory_quantity' => (int) $stock,
+        ]);
+      }
+      catch (Exception $e) {
+        // If the variant already exists, update it.
+        if ($e->getCode() == 400) {
+          $mc_ecommerce->updateProductVariant($store_id, $product_id, $product_variant_id, [
+            'description' => $description,
+            'type' => $type,
+            'title' => $title,
+            'sku' => $sku,
+            'url' => $url,
+            'price' => $price,
+            'image_url' => $image_url,
+          ]);
+        }
+        else {
+          mailchimp_ecommerce_log_error_message('Unable to add a product variant: ' . $e->getMessage());
+          mailchimp_ecommerce_show_error($e->getMessage());
+        }
+      }
     }
   }
   catch (Exception $e) {


### PR DESCRIPTION
During product sync in Commerce 7.x-1.x we call `mailchimp_ecommerce_commerce_commerce_product_insert()` which calls $mc->addProduct(). Unfortunately this results in API errors for product variants that already exist (error code 400) because we call addProductVariant() rather than updateProductVariant().

This PR allows us to update product variant if it already exists, calling updateProductVariant() instead if it receives a 400 error code.