### PR TITLE
Do not throw errors when addProduct returns 400

### DIFF
--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -958,7 +958,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
       }
     }
 
-    if ($e->getCode() != 404) {
+    if ($e->getCode() != 404 && $e->getCode() != 400) {
       // TODO: check if product has adjustments with additional SKUs defined. Add these as variants instead of default
       // No existing product; create new product with default variant.
       mailchimp_ecommerce_log_error_message('Unable to add a product: ' . $e->getMessage());


### PR DESCRIPTION
A one-line change to add the `400` error code to the excepted codes when calling `mailchimp_ecommerce_add_product()`. This is because we now check for this error code, which is returned as the result of a product (or variant) already existing. Therefore, having a successful `updateProductVariant()` also throw an error is confusing to the end user.