### PR TITLE
Use a call to url() to simplify product URL generation

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -704,8 +704,6 @@ function _mailchimp_ecommerce_commerce_build_order($order_wrapper) {
  *   The URL of the node referencing the product.
  */
 function _mailchimp_ecommerce_commerce_build_product_url($product) {
-  global $base_url;
-
   // MailChimp will accept an empty string if no URL is available.
   $url = '';
 
@@ -724,9 +722,7 @@ function _mailchimp_ecommerce_commerce_build_product_url($product) {
     $result = $query->execute();
     if (!empty($result) && !empty($result['node'])) {
       $node = reset($result['node']);
-
-      $path = drupal_get_path_alias('node/' . $node->nid);
-      $url = $base_url . '/' . $path;
+      $url = url('node/' . $node->nid, ['absolute' => TRUE]);
     }
   }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -448,11 +448,7 @@ function mailchimp_ecommerce_ubercart_parse_billing_address($order) {
  *   The URL of the node referencing the product.
  */
 function _mailchimp_ecommerce_ubercart_build_product_url($nid) {
-  global $base_url;
-
-  $path = drupal_get_path_alias('node/' . $nid);
-  $url = $base_url . '/' . $path;
-
+  $url = url('node/' . $node->nid, ['absolute' => TRUE]);
   return $url;
 }
 


### PR DESCRIPTION
In testing on a live dynamic environment that did not have `$base_url` configured, I found that the URL being sent to MC API for product URLs did not include the schema, resulting in broken landing pages. 

Aside from that, we can utilize `url()` without having to call `drupal_get_path_alias()` to simplify this process a bit.