### PR TITLE
Descriptions for products in Drupal Commerce 1.x

### DIFF
--- a/mailchimp_ecommerce.api.php
+++ b/mailchimp_ecommerce.api.php
@@ -16,3 +16,35 @@
 function hook_mailchimp_ecommerce_add_store($store) {
 
 }
+
+/**
+ * Allow other modules to alter the description of a product.
+ *
+ * @param string $description
+ *  Current value for the product description text.
+ *
+ * @param $product
+ *  The product being added or updated in Drupal.
+ */
+function hook_mailchimp_ecommerce_product_description_alter(&$description, $product) {
+  // In Commerce, the description for the product might reside in
+  // the display node, rather than the product entity.
+
+  // Query the database to find the display node.
+  $query = new EntityFieldQuery;
+  $query->entityCondition('entity_type', 'node')
+    ->fieldCondition('field_product', 'product_id', $product_id, '=')
+    ->range(0, 1);
+
+  $result = $query->execute();
+
+  if ($result && !empty($result['node'])) {
+    $nids[$product_id] = reset($result['node']);
+    $node = node_load($nids[$product_id]);
+
+    if (!isset($node->field_product_desription)) {
+      // The description lives in a custom field called product_description.
+      $description = check_plain($node->product_description[LANGUAGE_NONE][0]['value']);
+    }
+  }
+}

--- a/mailchimp_ecommerce.api.php
+++ b/mailchimp_ecommerce.api.php
@@ -27,13 +27,11 @@ function hook_mailchimp_ecommerce_add_store($store) {
  *  The product being added or updated in Drupal.
  */
 function hook_mailchimp_ecommerce_product_description_alter(&$description, $product) {
-  // In Commerce, the description for the product might reside in
-  // the display node, rather than the product entity.
-
-  // Query the database to find the display node.
+  // Query the database to find our custom display node.
   $query = new EntityFieldQuery;
   $query->entityCondition('entity_type', 'node')
-    ->fieldCondition('field_product', 'product_id', $product_id, '=')
+    ->entityCondition('bundle', 'custom_node_type')
+    ->fieldCondition('field_custom_product', 'product_id', $product_id, '=')
     ->range(0, 1);
 
   $result = $query->execute();
@@ -42,8 +40,8 @@ function hook_mailchimp_ecommerce_product_description_alter(&$description, $prod
     $nids[$product_id] = reset($result['node']);
     $node = node_load($nids[$product_id]);
 
+    // The description lives in a custom field called product_description.
     if (!isset($node->field_product_desription)) {
-      // The description lives in a custom field called product_description.
       $description = check_plain($node->product_description[LANGUAGE_NONE][0]['value']);
     }
   }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -884,7 +884,7 @@ function mailchimp_ecommerce_delete_order($order_id) {
  * @param int $stock
  *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description, $type, $sku, $url, $price, $image_url = '', $stock = 1) {
+function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $title, $description = '', $type, $sku, $url, $price, $image_url = '', $stock = 1) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -897,6 +897,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
     $variant = [
       'id'                 => $product_variant_id,
       'title'              => $title,
+      'description'        => $description,
       'sku'                => $sku,
       'url'                => $url,
       'price'              => $price,
@@ -950,7 +951,7 @@ function mailchimp_ecommerce_add_product($product_id, $product_variant_id, $titl
  * @param int $stock
  *   If enabled, the current active inventory.
  */
-function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $sku, $url, $price, $image_url = '', $stock = 1) {
+function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $title, $description = '', $sku, $url, $price, $image_url = '', $stock = 1) {
   try {
     $store_id = mailchimp_ecommerce_get_store_id();
     if (empty($store_id)) {
@@ -963,6 +964,7 @@ function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $t
     $variant = [
       'id'                 => $product_variant_id,
       'title'              => $title,
+      'description'        => $description,
       'sku'                => $sku,
       'url'                => $url,
       'price'              => $price,
@@ -973,6 +975,7 @@ function mailchimp_ecommerce_update_product($product_id, $product_variant_id, $t
     // This code only runs if the 404 isn't returned on get product.
     $mc_ecommerce->updateProduct($store_id, $product_id, [$variant], [
       'title' => $title,
+      'description' => $description,
       'sku' => $sku,
       'url' => $url,
       'price' => $price,

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -787,6 +787,24 @@ function _mailchimp_ecommerce_commerce_build_image_url($product) {
 }
 
 /**
+ * Get the description for a given product from its configured field.
+ */
+function _mailchimp_ecommerce_commerce_get_description($product) {
+  $description = '';
+  $field = variable_get('mailchimp_ecommerce_commerce_description_field' ,'');
+  if (!empty($field)) {
+    $wrapper = entity_metadata_wrapper('commerce_product', $product);
+    if ($wrapper->__isset($field) && $wrapper->{$field}->value()) {
+      $description = check_plain($wrapper->{$field}->value());
+
+      // Allow other modules to alter the description.
+      drupal_alter('mailchimp_ecommerce_product_description', $description, $product);
+    }
+  }
+  return $description;
+}
+
+/**
  * Find the inventory of a given product.
  *
  * @param object $product

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -516,7 +516,8 @@ function mailchimp_ecommerce_commerce_commerce_product_update($product) {
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
   $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
   $stock = _mailchimp_ecommerce_commerce_get_inventory($product);
-  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $product->sku, $url, $price, $image_url, $stock);
+  $description = _mailchimp_ecommerce_commerce_get_description($product);
+  mailchimp_ecommerce_update_product($product->product_id, $product->sku, $product->title, $description, $product->sku, $url, $price, $image_url, $stock);
 }
 
 /**

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -27,6 +27,10 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '' => '-- Select --',
   ];
 
+  $description_field_options = [
+    '' => '-- Select --',
+  ];
+
   $node_types = node_type_get_names();
 
   foreach ($node_types as $node_type => $node_name) {
@@ -65,6 +69,10 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
 
           // Track referenceable product variation types for this field.
           $product_image_types += array_filter($properties['settings']['referenceable_types']);
+        }
+
+        if (isset($properties['settings']['text_processing'])) {
+          $description_field_options[$field_name] = $properties['label'];
         }
       }
     }
@@ -110,6 +118,16 @@ function mailchimp_ecommerce_commerce_form_mailchimp_ecommerce_admin_settings_al
     '#title' => t('Image style'),
     '#description' => t('The image style to use when sending product images to MailChimp.'),
     '#default_value' => variable_get('mailchimp_ecommerce_commerce_image_style', ''),
+  ];
+
+  $form['product']['mailchimp_ecommerce_description_field'] = [
+    '#type' => 'select',
+    '#options' => $description_field_options,
+    '#title' => t('Description textfield'),
+    '#description' => t('Select the description text field used on the above content type.'),
+    '#default_value' => variable_get('mailchimp_ecommerce_description_field', ''),
+    '#prefix' => '<div id="node-field-wrapper">',
+    '#suffix' => '</div>',
   ];
 
   // If Stock modules are detected, show the admin some options for

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -798,11 +798,12 @@ function _mailchimp_ecommerce_commerce_get_description($product) {
     $wrapper = entity_metadata_wrapper('commerce_product', $product);
     if ($wrapper->__isset($field) && $wrapper->{$field}->value()) {
       $description = check_plain($wrapper->{$field}->value());
-
-      // Allow other modules to alter the description.
-      drupal_alter('mailchimp_ecommerce_product_description', $description, $product);
     }
   }
+
+  // Allow other modules to alter the description.
+  drupal_alter('mailchimp_ecommerce_product_description', $description, $product);
+
   return $description;
 }
 

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -793,10 +793,10 @@ function _mailchimp_ecommerce_commerce_build_image_url($product) {
  */
 function _mailchimp_ecommerce_commerce_get_description($product) {
   $description = '';
-  $field = variable_get('mailchimp_ecommerce_description_field' ,'');
+  $field_name = variable_get('mailchimp_ecommerce_description_field' ,'');
   $node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
 
-  if (!empty($field) && !empty($node_type)) {
+  if (!empty($field_name) && !empty($node_type)) {
     // Query the database to find the display node.
     $query = new EntityFieldQuery;
     $query->entityCondition('entity_type', 'node')
@@ -809,9 +809,16 @@ function _mailchimp_ecommerce_commerce_get_description($product) {
     if ($result && !empty($result['node'])) {
       $node = array_pop($result['node']);
       $node = node_load($node->nid);
-      $wrapper = entity_metadata_wrapper('node', $node);
-      if ($wrapper->__isset($field) && $wrapper->{$field}->value()) {
-        $description = $wrapper->{$field}->value(['sanitize' => TRUE])['value'];
+      if (isset($node->{$field_name}) && !empty($node->{$field_name})) {
+        $wrapper = entity_metadata_wrapper('node', $node);
+        // If this is a textfield with formatting, we need to pull
+        // the value from the 'value' subfield.
+        if ($wrapper->__isset($field_name->value) && $wrapper->{$field_name}->value->value()) {
+          $description = strip_tags($wrapper->{$field_name}->value->value());
+        }
+        else {
+          $description = strip_tags($wrapper->{$field_name}->value());
+        }
       }
     }
   }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -501,8 +501,10 @@ function mailchimp_ecommerce_commerce_commerce_product_insert($product) {
   $url = _mailchimp_ecommerce_commerce_build_product_url($product);
   $image_url = _mailchimp_ecommerce_commerce_build_image_url($product);
   $stock = _mailchimp_ecommerce_commerce_get_inventory($product);
+  $description = _mailchimp_ecommerce_commerce_get_description($product);
+
   // TODO: Get product description from product display, if available.
-  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, '', $product->type, $product->sku, $url, $price, $image_url, $stock);
+  mailchimp_ecommerce_add_product($product->product_id, $product->sku, $product->title, $description, $product->type, $product->sku, $url, $price, $image_url, $stock);
 }
 
 /**

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -793,11 +793,26 @@ function _mailchimp_ecommerce_commerce_build_image_url($product) {
  */
 function _mailchimp_ecommerce_commerce_get_description($product) {
   $description = '';
-  $field = variable_get('mailchimp_ecommerce_commerce_description_field' ,'');
-  if (!empty($field)) {
-    $wrapper = entity_metadata_wrapper('commerce_product', $product);
-    if ($wrapper->__isset($field) && $wrapper->{$field}->value()) {
-      $description = check_plain($wrapper->{$field}->value());
+  $field = variable_get('mailchimp_ecommerce_description_field' ,'');
+  $node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
+
+  if (!empty($field) && !empty($node_type)) {
+    // Query the database to find the display node.
+    $query = new EntityFieldQuery;
+    $query->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', $node_type)
+      ->fieldCondition('field_product', 'product_id', $product->product_id, '=')
+      ->range(0, 1);
+
+    $result = $query->execute();
+
+    if ($result && !empty($result['node'])) {
+      $node = array_pop($result['node']);
+      $node = node_load($node->nid);
+      $wrapper = entity_metadata_wrapper('node', $node);
+      if ($wrapper->__isset($field) && $wrapper->{$field}->value()) {
+        $description = $wrapper->{$field}->value(['sanitize' => TRUE])['value'];
+      }
     }
   }
 


### PR DESCRIPTION
This PR does the following:

- Adds a "Description field" option to the Admin UI;
- Adds a new `_mailchimp_ecommerce_commerce_get_description()` function;
- drupal_alters() the output so modules can adjust it for specialized needs
- Adds an example to mailchimp_ecommerce.api.php
- Default value of `$description` is an empty string, since other modules may be calling it (such as the Ubercart submodule, which does not build the description yet)

Please test :)