### PR TITLE
Add node hooks for insert, update and delete operations

### DIFF
--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -475,6 +475,99 @@ function mailchimp_ecommerce_commerce_commerce_checkout_complete($order) {
 }
 
 /**
+ * Implements hook_node_insert().
+ *
+ * When a node gets created, send it to MailChimp.
+ */
+function mailchimp_ecommerce_commerce_node_insert($node) {
+  $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
+
+  if (!empty($product_node_type) && $node->type == $product_node_type) {
+    // See if the configured product field exists.
+    $field = variable_get('mailchimp_ecommerce_product_node_field', '');
+    if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
+      $wrapper = entity_metadata_wrapper('node', $node);
+      if ($products = $wrapper->{$field}->value()) {
+        foreach ($products as $product) {
+          mailchimp_ecommerce_commerce_commerce_product_insert($product);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_node_update().
+ *
+ * Update a node at MailChimp when it is updated.
+ */
+function mailchimp_ecommerce_commerce_node_update($node) {
+  $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
+
+  if (!empty($product_node_type) && $node->type == $product_node_type) {
+    // See if the configured product field exists.
+    $field = variable_get('mailchimp_ecommerce_product_node_field', '');
+    if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
+      $wrapper = entity_metadata_wrapper('node', $node);
+      $ids = $wrapper->{$field}->raw();
+      foreach (array_values($ids) as $product_id) {
+        $query = new EntityFieldQuery();
+        $query->entityCondition('entity_type', 'node')
+          ->entityCondition('bundle', $product_node_type)
+          ->propertyCondition('nid', $node->nid, '<>')
+          ->fieldCondition($field, 'product_id', $product_id)
+          ->propertyCondition('status', TRUE)
+          ->range(0, 10);
+
+        $result = $query->execute();
+
+        if (!empty($result['node'])) {
+          $product = commerce_product_load($product_id);
+          mailchimp_ecommerce_commerce_commerce_product_update($product);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_node_delete().
+ *
+ * Delete a product at MailChimp, but only if no other nodes are referencing it.
+ */
+function mailchimp_ecommerce_commerce_node_delete($node) {
+  $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
+
+  if (!empty($product_node_type) && $node->type == $product_node_type) {
+    // See if the configured product field exists.
+    $field = variable_get('mailchimp_ecommerce_product_node_field', '');
+    if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
+      $wrapper = entity_metadata_wrapper('node', $node);
+      $ids = $wrapper->{$field}->raw();
+
+      if (!empty($ids)) {
+        foreach (array_values($ids) as $product_id) {
+          $query = new EntityFieldQuery();
+          $query->entityCondition('entity_type', 'node')
+            ->entityCondition('bundle', $product_node_type)
+            ->propertyCondition('nid', $node->nid, '<>')
+            ->fieldCondition($field, 'product_id', $product_id)
+            ->propertyCondition('status', TRUE)
+            ->range(0, 10);
+
+          $result = $query->execute();
+
+          if (empty($result['node'])) {
+            $product = commerce_product_load($product_id);
+            mailchimp_ecommerce_commerce_commerce_product_delete($product);
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_commerce_product_insert().
  */
 function mailchimp_ecommerce_commerce_commerce_product_insert($product) {

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -523,8 +523,7 @@ function mailchimp_ecommerce_commerce_node_update($node) {
           $query->entityCondition('entity_type', 'node')
             ->entityCondition('bundle', $product_node_type)
             ->fieldCondition($field, 'product_id', $product_id)
-            ->propertyCondition('status', TRUE)
-            ->range(0, 10);
+            ->propertyCondition('status', TRUE);
 
           $result = $query->execute();
 
@@ -563,8 +562,7 @@ function mailchimp_ecommerce_commerce_node_delete($node) {
             ->entityCondition('bundle', $product_node_type)
             ->propertyCondition('nid', $node->nid, '<>')
             ->fieldCondition($field, 'product_id', $product_id)
-            ->propertyCondition('status', TRUE)
-            ->range(0, 10);
+            ->propertyCondition('status', TRUE);
 
           $result = $query->execute();
 

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -485,8 +485,11 @@ function mailchimp_ecommerce_commerce_node_insert($node) {
   if (!empty($product_node_type) && $node->type == $product_node_type) {
     // See if the configured product field exists.
     $field = variable_get('mailchimp_ecommerce_product_node_field', '');
+
     if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
       $wrapper = entity_metadata_wrapper('node', $node);
+
+      // Only add a product if one is already referenced in the field.
       if ($products = $wrapper->{$field}->value()) {
         foreach ($products as $product) {
           mailchimp_ecommerce_commerce_commerce_product_insert($product);
@@ -507,9 +510,13 @@ function mailchimp_ecommerce_commerce_node_update($node) {
   if (!empty($product_node_type) && $node->type == $product_node_type) {
     // See if the configured product field exists.
     $field = variable_get('mailchimp_ecommerce_product_node_field', '');
+
+    // If the product reference field exists and has data, loop through
+    // the associated product IDs, looking for all product display nodes.
     if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
       $wrapper = entity_metadata_wrapper('node', $node);
       $ids = $wrapper->{$field}->raw();
+
       foreach (array_values($ids) as $product_id) {
         $query = new EntityFieldQuery();
         $query->entityCondition('entity_type', 'node')
@@ -520,6 +527,7 @@ function mailchimp_ecommerce_commerce_node_update($node) {
 
         $result = $query->execute();
 
+        // Update our available products.
         if (!empty($result['node'])) {
           $product = commerce_product_load($product_id);
           mailchimp_ecommerce_commerce_commerce_product_update($product);
@@ -538,12 +546,14 @@ function mailchimp_ecommerce_commerce_node_delete($node) {
   $product_node_type = variable_get('mailchimp_ecommerce_product_node_type', '');
 
   if (!empty($product_node_type) && $node->type == $product_node_type) {
+
     // See if the configured product field exists.
     $field = variable_get('mailchimp_ecommerce_product_node_field', '');
     if (!empty($field) && isset($node->{$field}) && !empty($node->{$field})) {
       $wrapper = entity_metadata_wrapper('node', $node);
       $ids = $wrapper->{$field}->raw();
 
+      // Find all product IDs referenced in our configured field.
       if (!empty($ids)) {
         foreach (array_values($ids) as $product_id) {
           $query = new EntityFieldQuery();
@@ -556,6 +566,7 @@ function mailchimp_ecommerce_commerce_node_delete($node) {
 
           $result = $query->execute();
 
+          // If no other nodes reference this product, we can delete it.
           if (empty($result['node'])) {
             $product = commerce_product_load($product_id);
             mailchimp_ecommerce_commerce_commerce_product_delete($product);

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -517,20 +517,22 @@ function mailchimp_ecommerce_commerce_node_update($node) {
       $wrapper = entity_metadata_wrapper('node', $node);
       $ids = $wrapper->{$field}->raw();
 
-      foreach (array_values($ids) as $product_id) {
-        $query = new EntityFieldQuery();
-        $query->entityCondition('entity_type', 'node')
-          ->entityCondition('bundle', $product_node_type)
-          ->fieldCondition($field, 'product_id', $product_id)
-          ->propertyCondition('status', TRUE)
-          ->range(0, 10);
+      if (!empty($ids)) {
+        foreach (array_values($ids) as $product_id) {
+          $query = new EntityFieldQuery();
+          $query->entityCondition('entity_type', 'node')
+            ->entityCondition('bundle', $product_node_type)
+            ->fieldCondition($field, 'product_id', $product_id)
+            ->propertyCondition('status', TRUE)
+            ->range(0, 10);
 
-        $result = $query->execute();
+          $result = $query->execute();
 
-        // Update our available products.
-        if (!empty($result['node'])) {
-          $product = commerce_product_load($product_id);
-          mailchimp_ecommerce_commerce_commerce_product_update($product);
+          // Update our available products.
+          if (!empty($result['node'])) {
+            $product = commerce_product_load($product_id);
+            mailchimp_ecommerce_commerce_commerce_product_update($product);
+          }
         }
       }
     }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -514,7 +514,6 @@ function mailchimp_ecommerce_commerce_node_update($node) {
         $query = new EntityFieldQuery();
         $query->entityCondition('entity_type', 'node')
           ->entityCondition('bundle', $product_node_type)
-          ->propertyCondition('nid', $node->nid, '<>')
           ->fieldCondition($field, 'product_id', $product_id)
           ->propertyCondition('status', TRUE)
           ->range(0, 10);


### PR DESCRIPTION
Now that we are referencing product display (node) types in the Commerce integration for D7, it seems like we should also have some `hook_node_$op` implementations to handle updates to those methods. It's probably very common for site admins to update a display node more than updating a product entity itself.

This PR does the following:
- Adds _insert, _update and _delete node hook implementations;
- For update and delete, checks for any other published nodes that reference the product.
  - Update() will fire if there are still products with display nodes, and Delete will NOT if this is the case (so that we do not delete the product itself from the MailChimp API). 

(Perhaps we need to invoke the update method for the product instead, so that the other display nodes are accounted for?)

Still a bit of a work in progress, could use some testing and feedback. Thanks!