### PR TITLE
Fix for product_url building in Ubercart D7

### DIFF
--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -452,7 +452,7 @@ function mailchimp_ecommerce_ubercart_parse_billing_address($order) {
  *   The URL of the node referencing the product.
  */
 function _mailchimp_ecommerce_ubercart_build_product_url($nid) {
-  $url = url('node/' . $node->nid, ['absolute' => TRUE]);
+  $url = url('node/' . $nid, ['absolute' => TRUE]);
   return $url;
 }
 


### PR DESCRIPTION
We're just getting the $nid, not the full $node object. Easy fix.