### PR TITLE
Create a database table to track orders locally.

### DIFF
--- a/mailchimp_ecommerce.install
+++ b/mailchimp_ecommerce.install
@@ -56,6 +56,39 @@ function mailchimp_ecommerce_schema() {
     ],
   ];
 
+  $schema['mailchimp_ecommerce_order'] = [
+    'description' => 'Maintains sync information between MailChimp and Drupal orders.',
+    'fields' => [
+      'id' => [
+        'description' => 'Primary Key (unique ID).',
+        'type' => 'serial',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+      ],
+      'order_id' => [
+        'description' => 'Internal Drupal order ID.',
+        'type' => 'varchar',
+        'length' => 254,
+        'not null' => FALSE,
+      ],
+      'store_id' => [
+        'description' => 'The MailChimp store ID this product belongs to.',
+        'type' => 'varchar',
+        'length' => 254,
+        'not null' => FALSE,
+      ],
+      'changed' => [
+        'type' => 'int',
+        'description' => 'Timestamp when order was last synced.',
+        'unsigned' => TRUE,
+        'default' => 0,
+      ],
+    ],
+    'primary key' => ['id'],
+    'indexes' => [
+      'order_id' => ['order_id', 'store_id'],
+    ],
+  ];
   return $schema;
 }
 
@@ -75,5 +108,15 @@ function mailchimp_ecommerce_update_7003() {
   // The table is renamed here, if it exists.
   if (db_table_exists('mailchimp_ecommerce')) {
     db_rename_table('mailchimp_ecommerce', 'mailchimp_ecommerce_customer');
+  }
+}
+
+/**
+ * Install the 'mailchimp_ecommerce_order' table to track carts and orders.
+ */
+function mailchimp_ecommerce_update_7004() {
+  if (!db_table_exists('mailchimp_ecommerce_order')) {
+    $table = drupal_get_schema_unprocessed('mailchimp_ecommerce', 'mailchimp_ecommerce_order');
+    db_create_table('mailchimp_ecommerce_order', $table);
   }
 }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -1349,7 +1349,7 @@ function _mailchimp_ecommerce_save_order($order_id, $store_id) {
     return $result;
   }
   catch (Exception $e) {
-    mailchimp_ecommerce_log_error_message(t('Could not save order to database. %msg', array('%msg' => $e->getMessage())));
+    mailchimp_ecommerce_log_error_message(t('Could not save order to database. %msg', ['%msg' => $e->getMessage()]));
   }
 }
 

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -1349,6 +1349,7 @@ function _mailchimp_ecommerce_save_order($order_id, $store_id) {
     return $result;
   }
   catch (Exception $e) {
+    mailchimp_ecommerce_show_error($e->getMessage());
     mailchimp_ecommerce_log_error_message(t('Could not save order to database. %msg', ['%msg' => $e->getMessage()]));
   }
 }

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -535,6 +535,7 @@ function mailchimp_ecommerce_delete_cart($cart_id) {
       /* @var \Mailchimp\MailchimpEcommerce $mc_ecommerce */
       $mc_ecommerce = mailchimp_get_api_object('MailchimpEcommerce');
       $mc_ecommerce->deleteCart($store_id, $cart_id);
+      _mailchimp_ecommerce_remove_order($cart_id, $store_id);
     }
   }
   catch (Exception $e) {

--- a/mailchimp_ecommerce.module
+++ b/mailchimp_ecommerce.module
@@ -441,6 +441,7 @@ function mailchimp_ecommerce_add_cart($cart_id, array $customer, array $cart) {
       $customer['opt_in_status'] = (isset($memberinfo->status) && ($memberinfo->status == 'subscribed')) ? TRUE : FALSE;
 
       $mc_ecommerce->addCart($store_id, $cart_id, $customer, $cart);
+      _mailchimp_ecommerce_save_order($cart_id, $store_id);
     }
   }
   catch (Exception $e) {
@@ -501,6 +502,7 @@ function mailchimp_ecommerce_update_cart($cart_id, array $customer, array $cart)
 
       $parameters += $cart;
       $mc_ecommerce->updateCart($store_id, $cart_id, $parameters);
+      _mailchimp_ecommerce_save_order($cart_id, $store_id);
     }
   }
   catch (Exception $e) {
@@ -1297,4 +1299,71 @@ function mailchimp_ecommerce_get_node_type_name($type_slug) {
   }
 
   return $type_name;
+}
+
+/**
+ * Get a local order_id based on the current store_id.
+ *
+ * @param string $order_id
+ *   The order ID we are looking for.
+ *
+ * @return string
+ *   The order ID if it exists, FALSE otherwise.
+ */
+function _mailchimp_ecommerce_get_order($order_id) {
+  $store_id = mailchimp_ecommerce_get_store_id();
+
+  $id = db_query("SELECT order_id FROM {mailchimp_ecommerce_order} WHERE store_id = :store_id AND order_id = :id",
+    [':store_id' => $store_id, ':id' => $order_id])->fetchField();
+
+  return !empty($id) ? $id : FALSE;
+}
+
+/**
+ * Save an order and its store to the database.
+ *
+ * @param string $order_id
+ *   Identifier for the  order.
+ * @param string $store_id
+ *   Unique value of the store that processed this order.
+ *
+ * @return bool
+ *   Success or failure.
+ */
+function _mailchimp_ecommerce_save_order($order_id, $store_id) {
+  try {
+    $result = db_merge('mailchimp_ecommerce_order')
+      ->key([
+        'store_id' => $store_id,
+        'order_id' => $order_id,
+      ])
+      ->insertFields([
+        'store_id' => $store_id,
+        'order_id' => $order_id,
+        'changed' => time(),
+      ])
+      ->updateFields([
+        'changed' => time(),
+      ])
+      ->execute();
+    return $result;
+  }
+  catch (Exception $e) {
+    mailchimp_ecommerce_log_error_message(t('Could not save order to database. %msg', array('%msg' => $e->getMessage())));
+  }
+}
+
+/**
+ * Save an order and its store to the database.
+ *
+ * @param string $order_id
+ *   Identifier for the  order.
+ * @param string $store_id
+ *   Unique value of the store that processed this order.
+ */
+function _mailchimp_ecommerce_remove_order($order_id, $store_id) {
+  db_delete('mailchimp_ecommerce_order')
+    ->condition('store_id', $store_id)
+    ->condition('order_id', $order_id)
+    ->execute();
 }

--- a/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
+++ b/modules/mailchimp_ecommerce_commerce/mailchimp_ecommerce_commerce.module
@@ -296,8 +296,11 @@ function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product
 
   // If this order is new, that means this is the first line item;
   // send the entire cart to MailChimp first.
-  if ($order->created == $order->changed) {
-    _mailchimp_ecommerce_commerce_send_cart($order);
+  $in_mc = _mailchimp_ecommerce_get_order($order->order_id);
+  if (!$in_mc) {
+    $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
+    $mc_order = _mailchimp_ecommerce_commerce_build_order($order_wrapper);
+    return mailchimp_ecommerce_add_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
   }
   else {
     $line_item_wrapper = entity_metadata_wrapper('commerce_line_item', $line_item);
@@ -309,7 +312,7 @@ function mailchimp_ecommerce_commerce_commerce_cart_product_add($order, $product
         $line_item_wrapper->commerce_unit_price->amount->value(),
         $line_item_wrapper->commerce_unit_price->currency_code->value()),
     ];
-    mailchimp_ecommerce_add_cart_line($order->order_id, $line_item->line_item_id, $cart_product);
+    return mailchimp_ecommerce_add_cart_line($order->order_id, $line_item->line_item_id, $cart_product);
   }
 }
 
@@ -592,13 +595,21 @@ function _mailchimp_ecommerce_commerce_send_cart($order) {
   }
   $order_wrapper = entity_metadata_wrapper('commerce_order', $order);
 
-  $mc_order = _mailchimp_ecommerce_commerce_build_order($order_wrapper);
-
-  if ($order->created == $order->changed) {
-    mailchimp_ecommerce_add_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
+  try {
+    $mc_order = _mailchimp_ecommerce_commerce_build_order($order_wrapper);
+    $in_mc = _mailchimp_ecommerce_get_order($order->order_id);
+    if (!$in_mc) {
+      $result = mailchimp_ecommerce_add_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
+    }
+    else {
+      $result = mailchimp_ecommerce_update_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
+    }
+    return $result;
   }
-  else {
-    mailchimp_ecommerce_update_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
+  catch (Exception $e) {
+    mailchimp_ecommerce_log_error_message(t('Unable to send cart: %msg', array('%msg' => $e->getMessage())));
+    mailchimp_ecommerce_show_error(t('Unable to send cart at MailChimp: %msg', array('%msg' => $e->getMessage())));
+    return FALSE;
   }
 }
 

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -535,10 +535,9 @@ function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
       }
     }
     else {
-      $cart = mailchimp_ecommerce_get_cart($order->order_id);
+      $cart = _mailchimp_ecommerce_get_order($order->order_id);
       if ($cart) {
         mailchimp_ecommerce_update_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);
-
       }
       else {
         mailchimp_ecommerce_add_cart($order->order_id, $mc_order['customer'], $mc_order['order_data']);

--- a/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
+++ b/modules/mailchimp_ecommerce_ubercart/mailchimp_ecommerce_ubercart.module
@@ -526,8 +526,8 @@ function mailchimp_ecommerce_ubercart_batch_add_orders($order_ids, &$context) {
 
     // check if the order exists so we can call the correct endpoint.
     if ($order->order_status == 'pending' || $order->order_status == 'complete') {
-      $order = mailchimp_ecommerce_get_order($order->order_id);
-      if ($order) {
+      $exists = mailchimp_ecommerce_get_order($order->order_id);
+      if ($exists) {
         mailchimp_ecommerce_update_order($order->order_id, $mc_order['order_data']);
       }
       else {


### PR DESCRIPTION
Based on our discussion in #126 this PR adds a table called `mailchimp_ecommerce_order` and adds get/save/remove helper functions that get called along with the appropriate MailChimp actions (like add_cart, delete_cart, add_order). 

This PR adds a check for the order_id in the database for Commerce (and fixes a broken check in Ubercart) and if found, updates. If not found, adds.

Pretty simple. Give it a look, thanks! 

(If this lands, I will update my PR in #126 to accommodate these changes.)